### PR TITLE
Feature/refactoring balance sheet

### DIFF
--- a/src/controllers/BalanceSheetController.ts
+++ b/src/controllers/BalanceSheetController.ts
@@ -4,7 +4,9 @@ import { writable, type Writable, get } from 'svelte/store';
 import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
 import { parse as parseCsv } from 'csv-parse/sync';
-import { extractConvertedAmount, extractNonReportingCurrencies } from '../utils/index';
+import { extractConvertedAmount, extractNonReportingCurrencies, parseAmount } from '../utils/index';
+import type { ChartConfiguration } from 'chart.js/auto';
+import { Logger } from '../utils/logger';
 
 /**
  * Interface representing a node in the balance sheet hierarchy.
@@ -56,6 +58,14 @@ export interface BalanceSheetState {
 	unconvertedWarning: string | null;
 	/** Current valuation method used. */
 	valuationMethod: 'convert' | 'cost' | 'units';
+	/** Chart.js configuration object for the net worth trend chart. */
+	chartConfig: ChartConfiguration | null;
+	/** Error specific to chart data loading. */
+	chartError: string | null;
+	/** Whether chart data is being reloaded (e.g. on interval toggle). */
+	chartLoading: boolean;
+	/** The active chart interval granularity. */
+	chartInterval: 'month' | 'week';
 }
 
 /**
@@ -88,6 +98,10 @@ export class BalanceSheetController {
 			hasUnconvertedCommodities: false,
 			unconvertedWarning: null,
 			valuationMethod: 'convert' as const,
+			chartConfig: null,
+			chartError: null,
+			chartLoading: false,
+			chartInterval: 'month' as const,
 		});
 	}
 
@@ -225,6 +239,141 @@ export class BalanceSheetController {
 	}
 
 	/**
+	 * Changes the chart interval granularity and reloads only the chart data.
+	 */
+	async setChartInterval(interval: 'month' | 'week') {
+		if (get(this.state).chartInterval === interval) return;
+		this.state.update(s => ({ ...s, chartInterval: interval, chartConfig: null, chartError: null, chartLoading: true }));
+		const reportingCurrency = this.plugin.settings.operatingCurrency;
+		try {
+			const result = await this.plugin.runQuery(queries.getHistoricalNetWorthDataQuery(interval, reportingCurrency));
+			this._processChartData(result, interval, reportingCurrency);
+		} catch (e) {
+			Logger.error('Error loading chart data:', e);
+			this.state.update(s => ({ ...s, chartLoading: false, chartError: `Failed to load chart: ${e.message}` }));
+		}
+	}
+
+	/**
+	 * Parses raw BQL result into chart config and updates the store.
+	 * Handles both monthly (3-col) and weekly (2-col) formats.
+	 */
+	private _processChartData(rawResult: string, interval: 'month' | 'week', reportingCurrency: string) {
+		try {
+			const clean = rawResult.replace(/\r/g, '').trim();
+			const records: string[][] = parseCsv(clean, { columns: false, skip_empty_lines: true, relax_column_count: true });
+			if (records.length === 0) throw new Error('No data available for chart.');
+
+			const dataMap = new Map<string, number>();
+			const labels: string[] = [];
+			const dataPoints: (number | null)[] = [];
+
+			if (interval === 'month') {
+				let minYear = Infinity, maxYear = -Infinity, minMonth = Infinity, maxMonth = -Infinity;
+				for (const row of records) {
+					if (row.length < 3) continue;
+					const year = parseInt(row[0].trim());
+					const monthNum = parseInt(row[1].trim());
+					const nw = parseAmount(extractConvertedAmount(row[2].trim(), reportingCurrency));
+					dataMap.set(`${year}-${monthNum.toString().padStart(2, '0')}`, nw.amount);
+					if (year < minYear || (year === minYear && monthNum < minMonth)) { minYear = year; minMonth = monthNum; }
+					if (year > maxYear || (year === maxYear && monthNum > maxMonth)) { maxYear = year; maxMonth = monthNum; }
+				}
+				let cy = minYear, cm = minMonth;
+				while (cy < maxYear || (cy === maxYear && cm <= maxMonth)) {
+					const key = `${cy}-${cm.toString().padStart(2, '0')}`;
+					labels.push(new Date(cy, cm - 1).toLocaleDateString('en-US', { year: 'numeric', month: 'short' }).toUpperCase());
+					dataPoints.push(dataMap.get(key) ?? null);
+					if (++cm > 12) { cm = 1; cy++; }
+				}
+			} else {
+				const dates: Date[] = [];
+				for (const row of records) {
+					if (row.length < 2) continue;
+					const dateStr = row[0].trim();
+					const d = new Date(dateStr + 'T00:00:00');
+					if (isNaN(d.getTime())) continue;
+					const nw = parseAmount(extractConvertedAmount(row[1].trim(), reportingCurrency));
+					dataMap.set(dateStr, nw.amount);
+					dates.push(d);
+				}
+				if (dates.length === 0) throw new Error('No weekly data.');
+				const minDate = new Date(Math.min(...dates.map(d => d.getTime())));
+				const maxDate = new Date(Math.max(...dates.map(d => d.getTime())));
+				const cur = new Date(minDate);
+				while (cur <= maxDate) {
+					const key = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, '0')}-${String(cur.getDate()).padStart(2, '0')}`;
+					labels.push(cur.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }));
+					dataPoints.push(dataMap.get(key) ?? null);
+					cur.setDate(cur.getDate() + 7);
+				}
+			}
+
+			const xAxisTitle = interval === 'month' ? 'Month' : 'Week ending (Sunday)';
+			this.state.update(s => ({ ...s, chartConfig: this._buildChartConfig(labels, dataPoints, reportingCurrency, xAxisTitle), chartError: null, chartLoading: false }));
+		} catch (err) {
+			Logger.error('Error processing chart data:', err);
+			this.state.update(s => ({ ...s, chartConfig: null, chartError: `Failed to process chart data: ${err.message}`, chartLoading: false }));
+		}
+	}
+
+	/**
+	 * Builds a Chart.js line chart configuration for the Net Worth Trend.
+	 */
+	private _buildChartConfig(labels: string[], dataPoints: (number | null)[], currency: string, xAxisTitle: string): ChartConfiguration {
+		return {
+			type: 'line',
+			data: {
+				labels,
+				datasets: [{
+					label: `Net Worth (${currency})`,
+					data: dataPoints,
+					borderColor: 'rgb(75, 192, 192)',
+					backgroundColor: 'rgba(75, 192, 192, 0.1)',
+					tension: 0.3,
+					fill: true,
+					pointRadius: 4,
+					pointHoverRadius: 6,
+					spanGaps: true
+				}]
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: {
+					title: {
+						display: true,
+						text: `Net Worth Trend (${currency})`,
+						font: { size: 16 }
+					},
+					legend: { display: true, position: 'top' },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							label: (context: any) => `Net Worth: ${context.parsed.y.toLocaleString()} ${currency}`
+						}
+					}
+				},
+				scales: {
+					x: {
+						display: true,
+						title: { display: true, text: xAxisTitle },
+						grid: { display: true, color: 'rgba(0, 0, 0, 0.1)' }
+					},
+					y: {
+						display: true,
+						title: { display: true, text: `Amount (${currency})` },
+						grid: { display: true, color: 'rgba(0, 0, 0, 0.1)' },
+						ticks: { callback: (value: any) => value.toLocaleString() }
+					}
+				},
+				interaction: { mode: 'nearest', axis: 'x', intersect: false }
+			}
+		};
+	}
+
+	/**
 	 * Main data fetching method.
 	 * Runs Beancount queries based on the valuation method and updates state.
 	 * @param {'convert' | 'cost' | 'units'} [valuationMethod='convert'] - The valuation method to use.
@@ -300,7 +449,9 @@ export class BalanceSheetController {
 				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the first column, other currencies are displayed separately in the second column. Only ${reportingCurrency} amounts are included in totals.`;
 			}
 
-			// Update the store with all new data
+			const currentState = get(this.state);
+
+			// Update the store with all new data (preserve chart state)
 			this.state.set({
 				isLoading: false,
 				error: null,
@@ -313,8 +464,21 @@ export class BalanceSheetController {
 				currency: reportingCurrency,
 				hasUnconvertedCommodities,
 				unconvertedWarning,
-				valuationMethod
+				valuationMethod,
+				chartConfig: currentState.chartConfig,
+				chartError: currentState.chartError,
+				chartLoading: true,
+				chartInterval: currentState.chartInterval,
 			});
+
+			// Load chart data
+			try {
+				const chartResult = await this.plugin.runQuery(queries.getHistoricalNetWorthDataQuery(currentState.chartInterval, reportingCurrency));
+				this._processChartData(chartResult, currentState.chartInterval, reportingCurrency);
+			} catch (chartErr) {
+				Logger.error('Error loading chart data in loadData:', chartErr);
+				this.state.update(s => ({ ...s, chartLoading: false, chartError: `Failed to load chart: ${chartErr.message}` }));
+			}
 
 		} catch (e) {
 			console.error("Error loading balance sheet:", e);

--- a/src/controllers/IncomeStatementController.ts
+++ b/src/controllers/IncomeStatementController.ts
@@ -1,0 +1,446 @@
+// src/controllers/IncomeStatementController.ts
+
+import { writable, type Writable, get } from 'svelte/store';
+import type BeancountPlugin from '../main';
+import * as queries from '../queries/index';
+import { parse as parseCsv } from 'csv-parse/sync';
+import { extractConvertedAmount, extractNonReportingCurrencies, parseAmount } from '../utils/index';
+import type { ChartConfiguration } from 'chart.js/auto';
+import { Logger } from '../utils/logger';
+// Re-export AccountItem so IncomeStatementTab can import from here
+export type { AccountItem } from './BalanceSheetController';
+import type { AccountItem } from './BalanceSheetController';
+
+/**
+ * Interface representing the state of the Income Statement view.
+ */
+export interface IncomeStatementState {
+	/** Whether data is loading. */
+	isLoading: boolean;
+	/** Error message if loading failed. */
+	error: string | null;
+	/** Tree of Income accounts. */
+	income: AccountItem[];
+	/** Tree of Expense accounts. */
+	expenses: AccountItem[];
+	/** Total numeric value of Income (absolute, positive). */
+	totalIncome: number;
+	/** Total numeric value of Expenses. */
+	totalExpenses: number;
+	/** Net profit (totalIncome - totalExpenses). */
+	netProfit: number;
+	/** The reporting currency used. */
+	currency: string;
+	/** Whether multi-currency entries were detected. */
+	hasUnconvertedCommodities: boolean;
+	/** Warning message for unconverted commodities. */
+	unconvertedWarning: string | null;
+	/** Current valuation method used. */
+	valuationMethod: 'convert' | 'cost' | 'units';
+	/** Chart.js configuration object for the net profit trend chart. */
+	chartConfig: ChartConfiguration | null;
+	/** Error specific to chart data loading. */
+	chartError: string | null;
+	/** Whether chart data is being reloaded. */
+	chartLoading: boolean;
+	/** The active chart interval granularity. */
+	chartInterval: 'month' | 'week';
+}
+
+/**
+ * IncomeStatementController
+ *
+ * Manages the data fetching and state for the Income Statement tab.
+ * Responsible for querying income/expense account balances, building the hierarchy,
+ * calculating totals, net profit, and handling different valuation methods.
+ */
+export class IncomeStatementController {
+	public plugin: BeancountPlugin;
+	public state: Writable<IncomeStatementState>;
+
+	constructor(plugin: BeancountPlugin) {
+		this.plugin = plugin;
+		this.state = writable({
+			isLoading: true,
+			error: null,
+			income: [],
+			expenses: [],
+			totalIncome: 0,
+			totalExpenses: 0,
+			netProfit: 0,
+			currency: plugin.settings.operatingCurrency || 'USD',
+			hasUnconvertedCommodities: false,
+			unconvertedWarning: null,
+			valuationMethod: 'convert' as const,
+			chartConfig: null,
+			chartError: null,
+			chartLoading: false,
+			chartInterval: 'month' as const,
+		});
+	}
+
+	/**
+	 * Builds a hierarchical structure from flat account entries.
+	 * Income account amounts are negated for display (they are stored as negative in beancount).
+	 */
+	private buildAccountHierarchy(
+		accounts: [string, string][],
+		accountType: 'Income' | 'Expenses',
+		valuationMethod: 'convert' | 'cost' | 'units' = 'convert'
+	): AccountItem[] {
+		const reportingCurrency = this.plugin.settings.operatingCurrency;
+		const accountMap = new Map<string, AccountItem>();
+		const rootAccounts: AccountItem[] = [];
+
+		for (const [fullAccount, rawAmount] of accounts) {
+			const convertedAmount = extractConvertedAmount(rawAmount, reportingCurrency);
+			const otherCurrencies = extractNonReportingCurrencies(rawAmount, reportingCurrency);
+
+			// Keep raw beancount sign: income is negative (credit), expenses are positive (debit)
+			const amountNumber = parseFloat(convertedAmount.split(' ')[0].replace(/,/g, '')) || 0;
+
+			const parts = fullAccount.split(':');
+			let currentPath = '';
+
+			for (let i = 0; i < parts.length; i++) {
+				const part = parts[i];
+				const parentPath = currentPath;
+				currentPath = currentPath ? `${currentPath}:${part}` : part;
+
+				if (!accountMap.has(currentPath)) {
+					const displayAmountNumber = i === parts.length - 1 ? amountNumber : 0;
+					const displayAmount = i === parts.length - 1
+						? `${amountNumber.toFixed(2)} ${reportingCurrency}`
+						: `0.00 ${reportingCurrency}`;
+
+					const item: AccountItem = {
+						account: currentPath,
+						displayName: part,
+						level: i,
+						amount: displayAmount,
+						amountNumber: displayAmountNumber,
+						otherCurrencies: i === parts.length - 1 ? otherCurrencies : '',
+						isCategory: i < parts.length - 1,
+						children: [],
+					};
+
+					accountMap.set(currentPath, item);
+
+					if (parentPath && accountMap.has(parentPath)) {
+						accountMap.get(parentPath)!.children!.push(item);
+					} else if (i === 0) {
+						rootAccounts.push(item);
+					}
+				} else if (i === parts.length - 1) {
+					const existing = accountMap.get(currentPath)!;
+					existing.amount = `${amountNumber.toFixed(2)} ${reportingCurrency}`;
+					existing.amountNumber = amountNumber;
+					existing.otherCurrencies = otherCurrencies;
+				}
+			}
+		}
+
+		this.calculateCategoryTotals(rootAccounts, reportingCurrency);
+		return rootAccounts;
+	}
+
+	/**
+	 * Recursively calculates totals for category nodes based on children.
+	 */
+	private calculateCategoryTotals(accounts: AccountItem[], currency: string): number {
+		let total = 0;
+		for (const account of accounts) {
+			if (account.children && account.children.length > 0) {
+				const childTotal = this.calculateCategoryTotals(account.children, currency);
+				account.amountNumber = childTotal;
+				account.amount = `${childTotal.toFixed(2)} ${currency}`;
+
+				const childOtherCurrencies = account.children
+					.map(child => child.otherCurrencies)
+					.filter(curr => curr && curr.trim() !== '')
+					.flatMap(curr => curr.split(/[,\n]/).map(c => c.trim()))
+					.filter((curr, index, arr) => arr.indexOf(curr) === index && curr !== '')
+					.join('\n');
+				account.otherCurrencies = childOtherCurrencies;
+
+				total += childTotal;
+			} else {
+				total += account.amountNumber;
+			}
+		}
+		return total;
+	}
+
+	/**
+	 * Flattens the hierarchy for rendering in a linear list.
+	 */
+	private flattenHierarchy(accounts: AccountItem[]): AccountItem[] {
+		const result: AccountItem[] = [];
+		const flatten = (items: AccountItem[]) => {
+			for (const item of items) {
+				result.push(item);
+				if (item.children && item.children.length > 0) {
+					flatten(item.children);
+				}
+			}
+		};
+		flatten(accounts);
+		return result;
+	}
+
+	/**
+	 * Sets the valuation method and reloads data.
+	 */
+	async setValuationMethod(method: 'convert' | 'cost' | 'units') {
+		await this.loadData(method);
+	}
+
+	/**
+	 * Changes the chart interval granularity and reloads only the chart data.
+	 */
+	async setChartInterval(interval: 'month' | 'week') {
+		if (get(this.state).chartInterval === interval) return;
+		this.state.update(s => ({ ...s, chartInterval: interval, chartConfig: null, chartError: null, chartLoading: true }));
+		const reportingCurrency = this.plugin.settings.operatingCurrency;
+		try {
+			const result = await this.plugin.runQuery(queries.getHistoricalNetProfitDataQuery(interval, reportingCurrency));
+			this._processChartData(result, interval, reportingCurrency);
+		} catch (e) {
+			Logger.error('Error loading income chart data:', e);
+			this.state.update(s => ({ ...s, chartLoading: false, chartError: `Failed to load chart: ${e.message}` }));
+		}
+	}
+
+	/**
+	 * Parses raw BQL result into a bar chart config and updates the store.
+	 * Handles both monthly (3-col) and weekly (2-col) formats.
+	 * Net profit = -(sum of Income+Expenses positions) because income is negative in beancount.
+	 */
+	private _processChartData(rawResult: string, interval: 'month' | 'week', reportingCurrency: string) {
+		try {
+			const clean = rawResult.replace(/\r/g, '').trim();
+			const records: string[][] = parseCsv(clean, { columns: false, skip_empty_lines: true, relax_column_count: true });
+			if (records.length === 0) throw new Error('No data available for chart.');
+
+			const dataMap = new Map<string, number>();
+			const labels: string[] = [];
+			const dataPoints: (number | null)[] = [];
+
+			if (interval === 'month') {
+				let minYear = Infinity, maxYear = -Infinity, minMonth = Infinity, maxMonth = -Infinity;
+				for (const row of records) {
+					if (row.length < 3) continue;
+					const year = parseInt(row[0].trim());
+					const monthNum = parseInt(row[1].trim());
+					// Keep raw sign: sum(Income+Expenses) is negative when profitable in beancount
+					const rawVal = parseAmount(extractConvertedAmount(row[2].trim(), reportingCurrency));
+					dataMap.set(`${year}-${monthNum.toString().padStart(2, '0')}`, rawVal.amount);
+					if (year < minYear || (year === minYear && monthNum < minMonth)) { minYear = year; minMonth = monthNum; }
+					if (year > maxYear || (year === maxYear && monthNum > maxMonth)) { maxYear = year; maxMonth = monthNum; }
+				}
+				let cy = minYear, cm = minMonth;
+				while (cy < maxYear || (cy === maxYear && cm <= maxMonth)) {
+					const key = `${cy}-${cm.toString().padStart(2, '0')}`;
+					labels.push(new Date(cy, cm - 1).toLocaleDateString('en-US', { year: 'numeric', month: 'short' }).toUpperCase());
+					dataPoints.push(dataMap.get(key) ?? null);
+					if (++cm > 12) { cm = 1; cy++; }
+				}
+			} else {
+				const dates: Date[] = [];
+				for (const row of records) {
+					if (row.length < 2) continue;
+					const dateStr = row[0].trim();
+					const d = new Date(dateStr + 'T00:00:00');
+					if (isNaN(d.getTime())) continue;
+					const rawVal = parseAmount(extractConvertedAmount(row[1].trim(), reportingCurrency));
+					dataMap.set(dateStr, rawVal.amount);
+					dates.push(d);
+				}
+				if (dates.length === 0) throw new Error('No weekly data.');
+				const minDate = new Date(Math.min(...dates.map(d => d.getTime())));
+				const maxDate = new Date(Math.max(...dates.map(d => d.getTime())));
+				const cur = new Date(minDate);
+				while (cur <= maxDate) {
+					const key = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, '0')}-${String(cur.getDate()).padStart(2, '0')}`;
+					labels.push(cur.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }));
+					dataPoints.push(dataMap.get(key) ?? null);
+					cur.setDate(cur.getDate() + 7);
+				}
+			}
+
+			const xAxisTitle = interval === 'month' ? 'Month' : 'Week ending (Sunday)';
+			this.state.update(s => ({
+				...s,
+				chartConfig: this._buildBarChartConfig(labels, dataPoints, reportingCurrency, xAxisTitle),
+				chartError: null,
+				chartLoading: false,
+			}));
+		} catch (err) {
+			Logger.error('Error processing income chart data:', err);
+			this.state.update(s => ({ ...s, chartConfig: null, chartError: `Failed to process chart data: ${err.message}`, chartLoading: false }));
+		}
+	}
+
+	/**
+	 * Builds a Chart.js bar chart configuration for the Net Profit Trend.
+	 */
+	private _buildBarChartConfig(labels: string[], dataPoints: (number | null)[], currency: string, xAxisTitle: string): ChartConfiguration {
+		return {
+			type: 'bar',
+			data: {
+				labels,
+				datasets: [{
+					label: `Net Profit (${currency})`,
+					data: dataPoints,
+					backgroundColor: dataPoints.map(v =>
+						v === null ? 'rgba(180,180,180,0.4)' :
+					v <= 0 ? 'rgba(75, 192, 130, 0.7)' : 'rgba(255, 99, 99, 0.7)'
+				),
+				borderColor: dataPoints.map(v =>
+					v === null ? 'rgba(180,180,180,0.6)' :
+					v <= 0 ? 'rgba(75, 192, 130, 1)' : 'rgba(255, 99, 99, 1)'
+					),
+					borderWidth: 1,
+				}],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: {
+					title: {
+						display: true,
+						text: `Net Profit Trend (${currency})`,
+						font: { size: 16 },
+					},
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							label: (context: any) => `Net Profit: ${context.parsed.y.toLocaleString()} ${currency}`,
+						},
+					},
+				},
+				scales: {
+					x: {
+						display: true,
+						title: { display: true, text: xAxisTitle },
+						grid: { display: false },
+					},
+					y: {
+						display: true,
+						title: { display: true, text: `Amount (${currency})` },
+						grid: { display: true, color: 'rgba(0, 0, 0, 0.1)' },
+						ticks: { callback: (value: any) => value.toLocaleString() },
+					},
+				},
+				interaction: { mode: 'nearest', axis: 'x', intersect: false },
+			},
+		};
+	}
+
+	/**
+	 * Main data fetching method.
+	 * Runs Beancount queries and updates the Income Statement state.
+	 */
+	async loadData(valuationMethod: 'convert' | 'cost' | 'units' = 'convert') {
+		this.state.update(s => ({ ...s, isLoading: true, error: null }));
+		const reportingCurrency = this.plugin.settings.operatingCurrency;
+
+		if (valuationMethod === 'convert' && !reportingCurrency) {
+			this.state.update(s => ({ ...s, isLoading: false, error: 'Operating currency not set.' }));
+			return;
+		}
+
+		try {
+			let query: string;
+			switch (valuationMethod) {
+				case 'convert':
+					query = queries.getIncomeStatementQuery(reportingCurrency);
+					break;
+				case 'cost':
+					query = queries.getIncomeStatementQueryByCost();
+					break;
+				case 'units':
+					query = queries.getIncomeStatementQueryByUnits();
+					break;
+			}
+
+			const result = await this.plugin.runQuery(query);
+			const cleanStdout = result.replace(/\r/g, '').trim();
+			const records: string[][] = parseCsv(cleanStdout, { columns: false, skip_empty_lines: true });
+
+			const firstRowIsHeader = records[0]?.[0]?.toLowerCase().includes('account');
+			const rows = firstRowIsHeader ? records.slice(1) : records;
+
+			let tempIncome: [string, string][] = [];
+			let tempExpenses: [string, string][] = [];
+			let hasUnconvertedCommodities = false;
+			const unconvertedAccounts: string[] = [];
+
+			for (const row of rows) {
+				if (row.length < 2) continue;
+				const [account, amountStr] = row;
+
+				if (valuationMethod === 'convert' && amountStr.includes(',')) {
+					hasUnconvertedCommodities = true;
+					unconvertedAccounts.push(account);
+				}
+
+				if (account.startsWith('Income')) {
+					tempIncome.push([account, amountStr]);
+				} else if (account.startsWith('Expenses')) {
+					tempExpenses.push([account, amountStr]);
+				}
+			}
+
+			const incomeHierarchy = this.buildAccountHierarchy(tempIncome, 'Income', valuationMethod);
+			const expensesHierarchy = this.buildAccountHierarchy(tempExpenses, 'Expenses', valuationMethod);
+
+			const totalIncome = this.calculateCategoryTotals(incomeHierarchy, reportingCurrency);
+			const totalExpenses = this.calculateCategoryTotals(expensesHierarchy, reportingCurrency);
+			// totalIncome is negative in beancount (credit accounts); compute conventional profit
+			const netProfit = -(totalIncome + totalExpenses);
+
+			let unconvertedWarning: string | null = null;
+			if (hasUnconvertedCommodities) {
+				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the first column, other currencies are displayed separately. Only ${reportingCurrency} amounts are included in totals.`;
+			}
+
+			const currentState = get(this.state);
+
+			this.state.set({
+				isLoading: false,
+				error: null,
+				income: this.flattenHierarchy(incomeHierarchy),
+				expenses: this.flattenHierarchy(expensesHierarchy),
+				totalIncome,
+				totalExpenses,
+				netProfit,
+				currency: reportingCurrency,
+				hasUnconvertedCommodities,
+				unconvertedWarning,
+				valuationMethod,
+				chartConfig: currentState.chartConfig,
+				chartError: currentState.chartError,
+				chartLoading: true,
+				chartInterval: currentState.chartInterval,
+			});
+
+			// Load chart data
+			try {
+				const chartResult = await this.plugin.runQuery(
+					queries.getHistoricalNetProfitDataQuery(currentState.chartInterval, reportingCurrency)
+				);
+				this._processChartData(chartResult, currentState.chartInterval, reportingCurrency);
+			} catch (chartErr) {
+				Logger.error('Error loading income chart data in loadData:', chartErr);
+				this.state.update(s => ({ ...s, chartLoading: false, chartError: `Failed to load chart: ${chartErr.message}` }));
+			}
+
+		} catch (e) {
+			console.error('Error loading income statement:', e);
+			this.state.update(s => ({ ...s, isLoading: false, error: e.message }));
+		}
+	}
+}

--- a/src/controllers/OverviewController.ts
+++ b/src/controllers/OverviewController.ts
@@ -1,11 +1,9 @@
 // src/controllers/OverviewController.ts
 
 import { writable, type Writable, get } from 'svelte/store';
-import type { ChartConfiguration } from 'chart.js/auto';
 import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
-import { parseAmount, extractConvertedAmount, parseSingleValue } from '../utils/index'; // Import helpers
-import { parse as parseCsv } from 'csv-parse/sync';
+import { parseSingleValue } from '../utils/index'; // Import helpers
 import { Logger } from '../utils/logger';
 
 /**
@@ -24,14 +22,6 @@ export interface OverviewState {
 	monthlyExpenses: string;
 	/** Savings rate percentage string (e.g. "20%"). */
 	savingsRate: string;
-	/** Chart.js configuration object for the net worth chart. */
-	chartConfig: ChartConfiguration | null;
-	/** Error specific to chart data loading. */
-	chartError: string | null;
-	/** Whether chart data is being reloaded (e.g. on interval toggle). */
-	chartLoading: boolean;
-	/** The active chart interval granularity. */
-	chartInterval: 'month' | 'week';
 	/** The reporting currency. */
 	currency: string;
 }
@@ -63,10 +53,6 @@ export class OverviewController {
 			monthlyIncome: '0.00 USD',
 			monthlyExpenses: '0.00 USD',
 			savingsRate: '0%',
-			chartConfig: null,
-			chartError: null,
-			chartLoading: false,
-			chartInterval: 'month',
 			currency: plugin.settings.operatingCurrency || 'USD',
 		});
 	}
@@ -88,17 +74,13 @@ export class OverviewController {
 			return;
 		}
 
-		const currentInterval = get(this.state).chartInterval;
-
 		try {
-			const [netWorthResult, incomeResult, expensesResult, savingsResult, historicalResult] = await Promise.all([
+			const [netWorthResult, incomeResult, expensesResult, savingsResult] = await Promise.all([
 				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, 2)),
 				this.plugin.runQuery(queries.getThisMonthIncomeQuery(reportingCurrency, 2)),
 				this.plugin.runQuery(queries.getThisMonthExpensesQuery(reportingCurrency, 2)),
 				this.plugin.runQuery(queries.getThisMonthSavingsQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getHistoricalNetWorthDataQuery(currentInterval, reportingCurrency))
 			]);
-			Logger.log("OverviewController: Historical Result:", historicalResult);
 
 			// Process KPI Data
 			Logger.log("OverviewController: Net Worth Result:", netWorthResult);
@@ -117,158 +99,12 @@ export class OverviewController {
 				currency: reportingCurrency,
 			};
 
-			// Update the store with KPI data, then process chart
+			// Update the store with KPI data
 			this.state.update(s => ({ ...s, ...newState, isLoading: false, error: null }));
-			this._processChartData(historicalResult, currentInterval, reportingCurrency);
 
 		} catch (e) {
 			Logger.error("Error loading overview data:", e);
 			this.state.update(s => ({ ...s, isLoading: false, error: `Failed to load data: ${e.message}` }));
 		}
-	}
-
-	/**
-	 * Changes the chart interval granularity and reloads only the chart data.
-	 */
-	async setChartInterval(interval: 'month' | 'week') {
-		if (get(this.state).chartInterval === interval) return;
-		this.state.update(s => ({ ...s, chartInterval: interval, chartConfig: null, chartError: null, chartLoading: true }));
-		const reportingCurrency = this.plugin.settings.operatingCurrency;
-		try {
-			const result = await this.plugin.runQuery(queries.getHistoricalNetWorthDataQuery(interval, reportingCurrency));
-			this._processChartData(result, interval, reportingCurrency);
-		} catch (e) {
-			Logger.error("Error loading chart data:", e);
-			this.state.update(s => ({ ...s, chartLoading: false, chartError: `Failed to load chart: ${e.message}` }));
-		}
-	}
-
-	/**
-	 * Parses raw BQL result into chart config and updates the store.
-	 * Handles both monthly (3-col) and weekly (2-col) formats.
-	 */
-	private _processChartData(rawResult: string, interval: 'month' | 'week', reportingCurrency: string) {
-		try {
-			const clean = rawResult.replace(/\r/g, "").trim();
-			Logger.log("OverviewController: _processChartData raw:", clean);
-			const records: string[][] = parseCsv(clean, { columns: false, skip_empty_lines: true, relax_column_count: true });
-			if (records.length === 0) throw new Error("No data available for chart.");
-
-			const dataMap = new Map<string, number>();
-			const labels: string[] = [];
-			const dataPoints: (number | null)[] = [];
-
-			if (interval === 'month') {
-				// cols: [year, month, value]
-				let minYear = Infinity, maxYear = -Infinity, minMonth = Infinity, maxMonth = -Infinity;
-				for (const row of records) {
-					if (row.length < 3) continue;
-					const year = parseInt(row[0].trim());
-					const monthNum = parseInt(row[1].trim());
-					const nw = parseAmount(extractConvertedAmount(row[2].trim(), reportingCurrency));
-					dataMap.set(`${year}-${monthNum.toString().padStart(2, '0')}`, nw.amount);
-					if (year < minYear || (year === minYear && monthNum < minMonth)) { minYear = year; minMonth = monthNum; }
-					if (year > maxYear || (year === maxYear && monthNum > maxMonth)) { maxYear = year; maxMonth = monthNum; }
-				}
-				let cy = minYear, cm = minMonth;
-				while (cy < maxYear || (cy === maxYear && cm <= maxMonth)) {
-					const key = `${cy}-${cm.toString().padStart(2, '0')}`;
-					labels.push(new Date(cy, cm - 1).toLocaleDateString('en-US', { year: 'numeric', month: 'short' }).toUpperCase());
-					dataPoints.push(dataMap.get(key) ?? null);
-					if (++cm > 12) { cm = 1; cy++; }
-				}
-			} else {
-				// cols: [week_end_date, value]  e.g. ["2025-12-22", " 614838.59 INR"]
-				const dates: Date[] = [];
-				for (const row of records) {
-					if (row.length < 2) continue;
-					const dateStr = row[0].trim();
-					const d = new Date(dateStr + 'T00:00:00');
-					if (isNaN(d.getTime())) continue; // skip header row
-					const nw = parseAmount(extractConvertedAmount(row[1].trim(), reportingCurrency));
-					dataMap.set(dateStr, nw.amount);
-					dates.push(d);
-				}
-				if (dates.length === 0) throw new Error("No weekly data.");
-				const minDate = new Date(Math.min(...dates.map(d => d.getTime())));
-				const maxDate = new Date(Math.max(...dates.map(d => d.getTime())));
-				const cur = new Date(minDate);
-				while (cur <= maxDate) {
-					// Use local date components to avoid UTC day-shift in non-UTC timezones (e.g. IST)
-					const key = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, '0')}-${String(cur.getDate()).padStart(2, '0')}`;
-					labels.push(cur.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }));
-					dataPoints.push(dataMap.get(key) ?? null);
-					cur.setDate(cur.getDate() + 7);
-				}
-			}
-
-			Logger.log("OverviewController: Chart labels:", labels);
-			Logger.log("OverviewController: Chart data points:", dataPoints);
-
-			const xAxisTitle = interval === 'month' ? 'Month' : 'Week ending (Sunday)';
-			this.state.update(s => ({ ...s, chartConfig: this._buildChartConfig(labels, dataPoints, reportingCurrency, xAxisTitle), chartError: null, chartLoading: false }));
-		} catch (err) {
-			Logger.error("Error processing chart data:", err);
-			this.state.update(s => ({ ...s, chartConfig: null, chartError: `Failed to process chart data: ${err.message}`, chartLoading: false }));
-		}
-	}
-
-	/**
-	 * Builds a Chart.js line chart configuration.
-	 */
-	private _buildChartConfig(labels: string[], dataPoints: (number | null)[], currency: string, xAxisTitle: string): ChartConfiguration {
-		return {
-			type: 'line',
-			data: {
-				labels,
-				datasets: [{
-					label: `Net Worth (${currency})`,
-					data: dataPoints,
-					borderColor: 'rgb(75, 192, 192)',
-					backgroundColor: 'rgba(75, 192, 192, 0.1)',
-					tension: 0.3,
-					fill: true,
-					pointRadius: 4,
-					pointHoverRadius: 6,
-					spanGaps: true
-				}]
-			},
-			options: {
-				responsive: true,
-				maintainAspectRatio: false,
-				plugins: {
-					title: {
-						display: true,
-						text: `Net Worth Trend (${currency})`,
-						font: { size: 16 }
-					},
-					legend: {
-						display: true,
-						position: 'top'
-					},
-							tooltip: {
-						mode: 'index',
-						intersect: false,
-						callbacks: {
-							label: (context: any) => `Net Worth: ${context.parsed.y.toLocaleString()} ${currency}`
-						}
-					}
-				},
-				scales: {
-					x: {
-						display: true,
-						title: { display: true, text: xAxisTitle },
-						grid: { display: true, color: 'rgba(0, 0, 0, 0.1)' }
-					},
-					y: {
-						display: true,
-						title: { display: true, text: `Amount (${currency})` },
-						grid: { display: true, color: 'rgba(0, 0, 0, 0.1)' },
-						ticks: { callback: (value: any) => value.toLocaleString() }
-					}
-				},
-				interaction: { mode: 'nearest', axis: 'x', intersect: false }
-			}
-		};
 	}
 }

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -57,8 +57,17 @@ export function getBalanceSheetQueryByUnits(): string {
 	return `SELECT account, units(sum(position)) WHERE account ~ '^(Assets|Liabilities|Equity)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
 }
 
-export function getAllAccountBalancesQuery(currency: string): string {
-	return `SELECT account, convert(sum(position), '${currency}') GROUP BY account ORDER BY account`;
+
+export function getIncomeStatementQuery(currency: string): string {
+	return `SELECT account, convert(sum(position), '${currency}') WHERE account ~ '^(Income|Expenses)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
+}
+
+export function getIncomeStatementQueryByCost(): string {
+	return `SELECT account, cost(sum(position)) WHERE account ~ '^(Income|Expenses)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
+}
+
+export function getIncomeStatementQueryByUnits(): string {
+	return `SELECT account, units(sum(position)) WHERE account ~ '^(Income|Expenses)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
 }
 
 export function getTransactionsQuery(filters: TransactionFilters, limit: number = 1000): string {
@@ -107,6 +116,14 @@ export function getHistoricalNetWorthDataQuery(interval: 'month' | 'week' = 'mon
 		return `SELECT last(date_add(date_trunc('week', date), 6)) AS week_end, only('${currency}', convert(last(balance), '${currency}', last(date_add(date_trunc('week', date), 6)))) WHERE account ~ '^(Assets|Liabilities)' GROUP BY date_trunc('week', date) ORDER BY week_end`;
 	}
 	return `SELECT year, month, only('${currency}', convert(last(balance), '${currency}', last(date_add(date(year + int(month/12), (month%12+1), 1), -1)))) WHERE account ~ '^(Assets|Liabilities)' GROUP BY year, month ORDER BY year, month`;
+}
+
+
+export function getHistoricalNetProfitDataQuery(interval: 'month' | 'week' = 'month', currency: string): string {
+	if (interval === 'week') {
+		return `SELECT last(date_add(date_trunc('week', date), 6)) AS week_end, only('${currency}', convert(sum(position), '${currency}', last(date_add(date_trunc('week', date), 6)))) WHERE account ~ '^(Income|Expenses)' GROUP BY date_trunc('week', date) ORDER BY week_end`;
+	}
+	return `SELECT year, month, only('${currency}', convert(sum(position), '${currency}', last(date_add(date(year + int(month/12), (month%12+1), 1), -1)))) AS _worth WHERE account ~ '^(Income|Expenses)' GROUP BY year, month ORDER BY year, month`;
 }
 
 // --- Commodities Queries ---

--- a/src/ui/common/SunburstChart.svelte
+++ b/src/ui/common/SunburstChart.svelte
@@ -18,6 +18,13 @@
 	export let totalLiabilities: number   = 0;
 	export let totalEquity: number        = 0;
 	export let title: string              = 'All Accounts';
+	// Optional overrides for section labels (used e.g. for Income Statement)
+	export let assetsLabel: string              = 'Assets';
+	export let liabilitiesLabel: string         = 'Liabilities';
+	export let equityLabel: string              = 'Equity';
+	// Expected sign per section: true = expect negative balance, false = expect positive
+	export let assetsExpectNegative: boolean      = false;
+	export let liabilitiesExpectNegative: boolean = true;  // beancount liabilities are credit (negative)
 
 	// ── SVG geometry ─────────────────────────────────────────────────────────
 	const SIZE    = 480;
@@ -77,10 +84,11 @@
 		return `hsl(${hue}, 65%, 55%)`;
 	}
 
-	// ── Anomaly detection (negative Assets/Equity, positive Liabilities) ─────
+	// ── Anomaly detection ────────────────────────────────────────────────────
 	function isAnomalous(section: string, negative: boolean): boolean {
-		if (section === 'Liabilities') return !negative; // positive liability is odd
-		return negative;                                  // negative asset/equity is odd
+		if (section === 'Assets')      return assetsExpectNegative ? !negative : negative;
+		if (section === 'Liabilities') return liabilitiesExpectNegative ? !negative : negative;
+		return negative; // equity: expect positive
 	}
 
 	// ── Layout builder ────────────────────────────────────────────────────────
@@ -186,11 +194,11 @@
 
 		const nodes: SunburstNode[] = [];
 		if (aSpan > 0.003)
-			nodes.push(syntheticRoot('__assets__',      'Assets',      'Assets',      totalAssets,      START,          START + aSpan,          aRoots));
+			nodes.push(syntheticRoot('__assets__',      assetsLabel,      'Assets',      totalAssets,      START,          START + aSpan,          aRoots));
 		if (lSpan > 0.003)
-			nodes.push(syntheticRoot('__liabilities__', 'Liabilities', 'Liabilities', totalLiabilities, START + aSpan,  START + aSpan + lSpan,  lRoots));
+			nodes.push(syntheticRoot('__liabilities__', liabilitiesLabel, 'Liabilities', totalLiabilities, START + aSpan,  START + aSpan + lSpan,  lRoots));
 		if (eSpan > 0.003)
-			nodes.push(syntheticRoot('__equity__',      'Equity',      'Equity',      totalEquity,      START + aSpan + lSpan, START + TAU,   eRoots));
+			nodes.push(syntheticRoot('__equity__',      equityLabel,      'Equity',      totalEquity,      START + aSpan + lSpan, START + TAU,   eRoots));
 
 		return nodes;
 	})();
@@ -284,9 +292,9 @@
 			: title;
 
 	$: centreSectionTotal = (() => {
-		if (title === 'Assets')      return totalAssets;
-		if (title === 'Liabilities') return totalLiabilities;
-		if (title === 'Equity')      return totalEquity;
+		if (title === assetsLabel)      return totalAssets;
+		if (title === liabilitiesLabel) return totalLiabilities;
+		if (title === equityLabel)      return totalEquity;
 		// "All Accounts" — show net worth (Assets minus Liabilities)
 		return Math.abs(totalAssets) - Math.abs(totalLiabilities);
 	})();
@@ -329,7 +337,7 @@
 			viewBox="0 0 {SIZE} {SIZE}"
 			class="sunburst-svg"
 			role="img"
-			aria-label="Balance Sheet Sunburst — Assets, Liabilities and Equity"
+			aria-label="Sunburst chart"
 		>
 			<defs>
 				<!-- Diagonal-stripe hatch for anomalous (unexpected-sign) accounts -->
@@ -418,18 +426,24 @@
 	<!-- Legend (shown at root level only) -->
 	{#if drillStack.length === 0}
 		<div class="sunburst-legend" aria-label="Chart legend">
-			<span class="legend-item">
-				<span class="legend-dot" style="background:{getColor('Assets', 0)};"></span>
-				Assets
-			</span>
-			<span class="legend-item">
-				<span class="legend-dot" style="background:{getColor('Liabilities', 0)};"></span>
-				Liabilities
-			</span>
-			<span class="legend-item">
-				<span class="legend-dot" style="background:{getColor('Equity', 0)};"></span>
-				Equity
-			</span>
+			{#if Math.abs(totalAssets) > 0.001}
+				<span class="legend-item">
+					<span class="legend-dot" style="background:{getColor('Assets', 0)};"></span>
+					{assetsLabel}
+				</span>
+			{/if}
+			{#if Math.abs(totalLiabilities) > 0.001}
+				<span class="legend-item">
+					<span class="legend-dot" style="background:{getColor('Liabilities', 0)};"></span>
+					{liabilitiesLabel}
+				</span>
+			{/if}
+			{#if Math.abs(totalEquity) > 0.001}
+				<span class="legend-item">
+					<span class="legend-dot" style="background:{getColor('Equity', 0)};"></span>
+					{equityLabel}
+				</span>
+			{/if}
 		</div>
 	{/if}
 
@@ -445,7 +459,7 @@
 				<rect width="14" height="14" rx="2" fill="var(--background-modifier-border)" />
 				<rect width="14" height="14" rx="2" fill="url(#hatch-hint-pat)" />
 			</svg>
-			Stripes = unexpected sign (e.g. overdrawn asset, credit liability)
+			Stripes = unexpected sign
 		</p>
 	{/if}
 

--- a/src/ui/common/SunburstChart.svelte
+++ b/src/ui/common/SunburstChart.svelte
@@ -17,6 +17,7 @@
 	export let totalAssets: number        = 0;
 	export let totalLiabilities: number   = 0;
 	export let totalEquity: number        = 0;
+	export let title: string              = 'All Accounts';
 
 	// ── SVG geometry ─────────────────────────────────────────────────────────
 	const SIZE    = 480;
@@ -39,6 +40,7 @@
 		endAngle:     number;
 		depth:        number;
 		section:      'Assets' | 'Liabilities' | 'Equity';
+		negative:     boolean;  // true if source item has negative amountNumber
 		sourceItem:   AccountItem | null;
 		children:     SunburstNode[];
 	}
@@ -63,16 +65,22 @@
 		Equity:      213,
 	};
 
-	function getColor(section: string, depth: number): string {
+	function getColor(section: string, depth: number, negative: boolean = false): string {
 		const hue  = SECTION_HUE[section] ?? 200;
-		const sat  = 48;
+		const sat  = 52;
 		const lig  = Math.min(72, 36 + depth * 10);
 		return `hsl(${hue}, ${sat}%, ${lig}%)`;
 	}
 
-	function getHoverColor(section: string): string {
+	function getHoverColor(section: string, negative: boolean = false): string {
 		const hue = SECTION_HUE[section] ?? 200;
-		return `hsl(${hue}, 60%, 55%)`;
+		return `hsl(${hue}, 65%, 55%)`;
+	}
+
+	// ── Anomaly detection (negative Assets/Equity, positive Liabilities) ─────
+	function isAnomalous(section: string, negative: boolean): boolean {
+		if (section === 'Liabilities') return !negative; // positive liability is odd
+		return negative;                                  // negative asset/equity is odd
 	}
 
 	// ── Layout builder ────────────────────────────────────────────────────────
@@ -99,17 +107,19 @@
 			if (slice < 0.003) { angle += slice; continue; } // skip near-invisible arcs
 
 			const p = parentPath ? `${parentPath} › ${item.displayName}` : item.displayName;
+			const isNeg = item.amountNumber < 0;
 			const node: SunburstNode = {
 				id:          item.account,
 				label:       item.displayName,
 				path:        p,
 				amount:      item.amount,
 				value:       Math.abs(item.amountNumber),
-				color:       getColor(section, depth),
+				color:       getColor(section, depth, isNeg),
 				startAngle:  angle,
 				endAngle:    angle + slice,
 				depth,
 				section:     section as SunburstNode['section'],
+				negative:    isNeg,
 				sourceItem:  item,
 				children:    item.children?.length
 					? buildNodes(item.children, section, angle, angle + slice, depth + 1, p)
@@ -161,11 +171,12 @@
 				id, label, path: label,
 				amount:     `${value.toFixed(2)} ${currency}`,
 				value:      Math.abs(value),
-				color:      getColor(section, 0),
+				color:      getColor(section, 0, value < 0),
 				startAngle: sa,
 				endAngle:   ea,
 				depth:      0,
 				section,
+				negative:   value < 0,
 				sourceItem: roots[0] ?? null,
 				children:   ring1Items.length
 					? buildNodes(ring1Items, section, sa, ea, 1, label)
@@ -270,12 +281,20 @@
 		? hoveredNode.label
 		: drillStack.length > 0
 			? (drillStack[drillStack.length - 1].crumb.split(' › ').pop() ?? '')
-			: 'Balance';
+			: title;
+
+	$: centreSectionTotal = (() => {
+		if (title === 'Assets')      return totalAssets;
+		if (title === 'Liabilities') return totalLiabilities;
+		if (title === 'Equity')      return totalEquity;
+		// "All Accounts" — show net worth (Assets minus Liabilities)
+		return Math.abs(totalAssets) - Math.abs(totalLiabilities);
+	})();
 
 	$: centreAmount = hoveredNode
 		? hoveredNode.amount
 		: drillStack.length === 0
-			? `${(Math.abs(totalAssets) - Math.abs(totalLiabilities)).toFixed(2)} ${currency}`
+			? `${centreSectionTotal.toFixed(2)} ${currency}`
 			: '';
 </script>
 
@@ -287,7 +306,7 @@
 			class="crumb-btn"
 			class:active={drillStack.length === 0}
 			on:click={() => drillBack(0)}
-		>All Accounts</button>
+		>{title}</button>
 
 		{#each drillStack as level, i}
 			<span class="crumb-sep" aria-hidden="true">›</span>
@@ -312,12 +331,19 @@
 			role="img"
 			aria-label="Balance Sheet Sunburst — Assets, Liabilities and Equity"
 		>
+			<defs>
+				<!-- Diagonal-stripe hatch for anomalous (unexpected-sign) accounts -->
+				<pattern id="hatch-anomalous" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)">
+					<line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.55)" stroke-width="3"/>
+				</pattern>
+			</defs>
+
 			<!-- ── Arcs ── -->
 			{#each allNodes as node (node.id + '|' + node.depth + '|' + node.startAngle.toFixed(4))}
 				<!-- svelte-ignore a11y-click-events-have-key-events -->
 				<path
 					d={arcPath(node)}
-					fill={hoveredNode === node ? getHoverColor(node.section) : node.color}
+					fill={hoveredNode === node ? getHoverColor(node.section, node.negative) : node.color}
 					stroke="var(--background-primary)"
 					stroke-width="1.5"
 					style="cursor:{node.sourceItem?.children?.length ? 'pointer' : 'default'};transition:fill 0.12s ease;"
@@ -328,6 +354,15 @@
 					aria-label="{node.path}: {node.amount}"
 					on:keydown={(e) => e.key === 'Enter' && onArcClick(node)}
 				/>
+				<!-- Stripe overlay for anomalous-sign accounts -->
+				{#if isAnomalous(node.section, node.negative)}
+					<path
+						d={arcPath(node)}
+						fill="url(#hatch-anomalous)"
+						stroke="none"
+						pointer-events="none"
+					/>
+				{/if}
 			{/each}
 
 			<!-- ── Inline labels (depth 0 & 1 only, only if arc is wide enough) ── -->
@@ -396,6 +431,22 @@
 				Equity
 			</span>
 		</div>
+	{/if}
+
+	<!-- Hatch pattern hint -->
+	{#if grandTotal >= 0.001}
+		<p class="hatch-hint">
+			<svg width="14" height="14" style="vertical-align:-2px;margin-right:4px;">
+				<defs>
+					<pattern id="hatch-hint-pat" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)">
+						<line x1="0" y1="0" x2="0" y2="8" stroke="var(--text-muted)" stroke-width="3"/>
+					</pattern>
+				</defs>
+				<rect width="14" height="14" rx="2" fill="var(--background-modifier-border)" />
+				<rect width="14" height="14" rx="2" fill="url(#hatch-hint-pat)" />
+			</svg>
+			Stripes = unexpected sign (e.g. overdrawn asset, credit liability)
+		</p>
 	{/if}
 
 	<!-- Empty state -->
@@ -511,5 +562,14 @@
 		font-size: var(--font-ui-small);
 		text-align: center;
 		padding: var(--size-4-4);
+	}
+
+	.hatch-hint {
+		margin: 0;
+		font-size: 11px;
+		color: var(--text-faint);
+		display: flex;
+		align-items: center;
+		gap: 4px;
 	}
 </style>

--- a/src/ui/partials/dashboard/BalanceSheetTab.svelte
+++ b/src/ui/partials/dashboard/BalanceSheetTab.svelte
@@ -5,9 +5,12 @@
 	import { Logger } from '../../../utils/logger';
 	import { AccountManagementModal } from '../../modals/AccountManagementModal';
 	import SunburstChart from '../../common/SunburstChart.svelte';
+	import ChartComponent from '../../common/ChartComponent.svelte';
 
-	// View mode: 'table' shows the existing hierarchy tables, 'sunburst' shows the radial chart
-	let viewMode: 'table' | 'sunburst' = 'table';
+	// Chart selector: which chart is shown in the chart area
+	let selectedChart: 'trend' | 'balances' = 'trend';
+	// Sub-selector for Balances view
+	let selectedBalanceSection: 'assets' | 'liabilities' | 'equity' = 'assets';
 
 	// --- Receive the controller ---
 	export let controller: BalanceSheetController;
@@ -16,7 +19,8 @@
 	const placeholderState: Writable<BalanceSheetState> = writable({
 		isLoading: true, error: null, assets: [], liabilities: [], equity: [],
 		totalAssets: 0, totalLiabilities: 0, totalEquity: 0, currency: 'INR',
-		hasUnconvertedCommodities: false, unconvertedWarning: null, valuationMethod: 'convert'
+		hasUnconvertedCommodities: false, unconvertedWarning: null, valuationMethod: 'convert',
+		chartConfig: null, chartError: null, chartLoading: false, chartInterval: 'month'
 	});
 	$: stateStore = controller ? controller.state : placeholderState;
 	$: state = $stateStore;
@@ -139,11 +143,18 @@
 			controller.loadData();
 		}
 	}
+
+	function handleIntervalChange(interval: 'month' | 'week') {
+		if (controller && state.chartInterval !== interval) {
+			controller.setChartInterval(interval);
+		}
+	}
 </script>
 
 <div class="balance-sheet-container">
+	<!-- Header: Title + Account Management buttons + Refresh -->
 	<div class="balance-sheet-header">
-		<h2>Accounts & Balance Sheet</h2>
+		<h2>Accounts and Balances</h2>
 		<div class="header-controls">
 			<div class="account-management-section">
 				<button class="account-action-btn open-account-btn" on:click={handleOpenAccount}>
@@ -153,55 +164,11 @@
 					❌ Close Account
 				</button>
 			</div>
-			<div class="valuation-method-selector">
-				<label for="valuation-method">Valuation:</label>
-				<select 
-					id="valuation-method" 
-					value={state.valuationMethod || 'convert'} 
-					on:change={handleValuationMethodChange}
-				>
-					<option value="convert">Market Value (Convert to {state.currency})</option>
-					<option value="cost">At Cost</option>
-					<option value="units">Units</option>
-				</select>
-			</div>
-			<!-- View mode toggle -->
-			<div class="view-toggle" role="group" aria-label="View mode">
-				<button
-					class="view-toggle-btn"
-					class:active={viewMode === 'table'}
-					on:click={() => (viewMode = 'table')}
-					title="Table view"
-					aria-pressed={viewMode === 'table'}
-				>
-					<!-- Table icon -->
-					<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-						<rect x="3" y="3" width="18" height="18" rx="2"/>
-						<path d="M3 9h18M3 15h18M9 3v18"/>
-					</svg>
-					Table
-				</button>
-				<button
-					class="view-toggle-btn"
-					class:active={viewMode === 'sunburst'}
-					on:click={() => (viewMode = 'sunburst')}
-					title="Sunburst chart"
-					aria-pressed={viewMode === 'sunburst'}
-				>
-					<!-- Sunburst / radial icon -->
-					<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-						<circle cx="12" cy="12" r="3"/>
-						<circle cx="12" cy="12" r="7"/>
-						<circle cx="12" cy="12" r="11"/>
-					</svg>
-					Sunburst
-				</button>
-			</div>
 			<button
 				on:click={handleRefresh}
 				disabled={state.isLoading}
 				class="refresh-button"
-				title="Refresh balance sheet data"
+				title="Refresh data"
 			>
 				{#if state.isLoading}
 					<svg class="loading-spinner" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -222,7 +189,7 @@
 	</div>
 
 	{#if state.isLoading}
-		<p>Loading balance sheet...</p>
+		<p>Loading data...</p>
 	{:else if state.error}
 		<p class="error-message">{state.error}</p>
 	{:else}
@@ -234,17 +201,134 @@
 			</div>
 		{/if}
 
-		{#if viewMode === 'sunburst'}
-			<SunburstChart
-				assets={state.assets}
-				liabilities={state.liabilities}
-				equity={state.equity}
-				currency={state.currency}
-				totalAssets={state.totalAssets}
-				totalLiabilities={state.totalLiabilities}
-				totalEquity={state.totalEquity}
-			/>
-		{:else}
+		<!-- Chart Area -->
+		<div class="chart-area">
+			<div class="chart-area-header">
+				<div class="chart-selector" role="group" aria-label="Select chart">
+					<button
+						class="chart-selector-btn"
+						class:active={selectedChart === 'trend'}
+						on:click={() => (selectedChart = 'trend')}
+						aria-pressed={selectedChart === 'trend'}
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+						</svg>
+						Net Worth Trend
+					</button>
+					<button
+						class="chart-selector-btn"
+						class:active={selectedChart === 'balances'}
+						on:click={() => (selectedChart = 'balances')}
+						aria-pressed={selectedChart === 'balances'}
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<circle cx="12" cy="12" r="3"/>
+							<circle cx="12" cy="12" r="7"/>
+							<circle cx="12" cy="12" r="11"/>
+						</svg>
+						Balances
+					</button>
+				</div>
+				{#if selectedChart === 'trend'}
+					<div class="interval-toggle">
+						<button
+							class:active={state.chartInterval === 'month'}
+							on:click={() => handleIntervalChange('month')}
+							disabled={state.chartLoading}
+						>Monthly</button>
+						<button
+							class:active={state.chartInterval === 'week'}
+							on:click={() => handleIntervalChange('week')}
+							disabled={state.chartLoading}
+						>Weekly</button>
+					</div>
+				{:else if selectedChart === 'balances'}
+					<div class="balance-section-toggle">
+						<button
+							class:active={selectedBalanceSection === 'assets'}
+							on:click={() => (selectedBalanceSection = 'assets')}
+						>Assets</button>
+						<button
+							class:active={selectedBalanceSection === 'liabilities'}
+							on:click={() => (selectedBalanceSection = 'liabilities')}
+						>Liabilities</button>
+						<button
+							class:active={selectedBalanceSection === 'equity'}
+							on:click={() => (selectedBalanceSection = 'equity')}
+						>Equity</button>
+					</div>
+				{/if}
+			</div>
+
+			{#if selectedChart === 'trend'}
+				<div class="trend-chart-container">
+					{#if state.chartError}
+						<p class="error-message">Chart Error: {state.chartError}</p>
+					{:else if state.chartLoading}
+						<p class="chart-loading">Loading chart...</p>
+					{:else if state.chartConfig}
+						<ChartComponent config={state.chartConfig} height="300px"/>
+					{:else}
+						<p class="chart-loading">Not enough data to display chart.</p>
+					{/if}
+				</div>
+			{:else if selectedChart === 'balances'}
+				{#if selectedBalanceSection === 'assets'}
+					<SunburstChart
+						title="Assets"
+						assets={state.assets}
+						liabilities={[]}
+						equity={[]}
+						currency={state.currency}
+						totalAssets={state.totalAssets}
+						totalLiabilities={0}
+						totalEquity={0}
+					/>
+				{:else if selectedBalanceSection === 'liabilities'}
+					<SunburstChart
+						title="Liabilities"
+						assets={[]}
+						liabilities={state.liabilities}
+						equity={[]}
+						currency={state.currency}
+						totalAssets={0}
+						totalLiabilities={state.totalLiabilities}
+						totalEquity={0}
+					/>
+				{:else}
+					<SunburstChart
+						title="Equity"
+						assets={[]}
+						liabilities={[]}
+						equity={state.equity}
+						currency={state.currency}
+						totalAssets={0}
+						totalLiabilities={0}
+						totalEquity={state.totalEquity}
+					/>
+				{/if}
+			{/if}
+		</div>
+
+		<!-- Balance Sheet (always visible) -->
+		<div class="balance-sheet-section">
+			<div class="balance-sheet-section-header">
+				<h3>Balance Sheet</h3>
+				<div class="valuation-method-selector">
+					<label for="valuation-method">Valuation:</label>
+					<select
+						id="valuation-method"
+						value={state.valuationMethod || 'convert'}
+						on:change={handleValuationMethodChange}
+					>
+						<option value="convert">Market Value (Convert to {state.currency})</option>
+						<option value="cost">At Cost</option>
+						<option value="units">Units</option>
+					</select>
+				</div>
+			</div>
+
 		<div class="balance-sheet-grid">
 			<div class="column">
 				<h4>Assets</h4>
@@ -357,7 +441,7 @@
 				</table>
 			</div>
 		</div>
-		{/if}
+		</div>
 	{/if}
 </div>
 
@@ -385,7 +469,7 @@
 
 	.header-controls {
 		display: flex;
-		gap: var(--size-4-6);
+		gap: var(--size-4-4);
 		align-items: center;
 		flex-wrap: wrap;
 	}
@@ -422,9 +506,124 @@
 		color: var(--text-on-accent);
 	}
 
-	.balance-sheet-header h2:not(:first-child) {
+	/* Chart area */
+	.chart-area {
+		margin-bottom: var(--size-4-8);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: var(--size-4-4);
+		background: var(--background-secondary);
+	}
+
+	.chart-area-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--size-4-4);
+		flex-wrap: wrap;
+		gap: var(--size-4-2);
+	}
+
+	.chart-selector {
+		display: flex;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		overflow: hidden;
+	}
+
+	.chart-selector-btn {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 4px 12px;
+		border: none;
+		background: var(--interactive-normal);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.chart-selector-btn:not(:last-child) {
+		border-right: 1px solid var(--background-modifier-border);
+	}
+
+	.chart-selector-btn:hover {
+		background: var(--interactive-hover);
+		color: var(--text-normal);
+	}
+
+	.chart-selector-btn.active {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+
+	.interval-toggle,
+	.balance-section-toggle {
+		display: flex;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		overflow: hidden;
+	}
+
+	.interval-toggle button,
+	.balance-section-toggle button {
+		padding: var(--size-4-1) var(--size-4-3);
+		background: var(--interactive-normal);
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: background-color 0.15s, color 0.15s;
+	}
+
+	.interval-toggle button:not(:last-child),
+	.balance-section-toggle button:not(:last-child) {
+		border-right: 1px solid var(--background-modifier-border);
+	}
+
+	.interval-toggle button.active,
+	.balance-section-toggle button.active {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+
+	.interval-toggle button:hover:not(.active):not(:disabled),
+	.balance-section-toggle button:hover:not(.active) {
+		background: var(--interactive-hover);
+		color: var(--text-normal);
+	}
+
+	.interval-toggle button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.trend-chart-container {
+		height: 320px;
+		position: relative;
+	}
+
+	/* Balance Sheet section */
+	.balance-sheet-section {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: var(--size-4-4);
+	}
+
+	.balance-sheet-section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--size-4-4);
+		flex-wrap: wrap;
+		gap: var(--size-4-2);
+	}
+
+	.balance-sheet-section-header h3 {
 		margin: 0;
 		color: var(--text-normal);
+		font-size: var(--font-ui-larger);
 	}
 
 	.valuation-method-selector {
@@ -437,42 +636,6 @@
 		font-size: 0.9em;
 		color: var(--text-muted);
 		white-space: nowrap;
-	}
-
-	/* View toggle (Table / Sunburst) */
-	.view-toggle {
-		display: flex;
-		border: 1px solid var(--background-modifier-border);
-		border-radius: var(--radius-s);
-		overflow: hidden;
-	}
-
-	.view-toggle-btn {
-		display: flex;
-		align-items: center;
-		gap: 5px;
-		padding: 4px 10px;
-		border: none;
-		background: var(--interactive-normal);
-		color: var(--text-muted);
-		cursor: pointer;
-		font-size: var(--font-ui-small);
-		transition: background 0.15s, color 0.15s;
-		border-right: 1px solid var(--background-modifier-border);
-	}
-
-	.view-toggle-btn:last-child {
-		border-right: none;
-	}
-
-	.view-toggle-btn:hover {
-		background: var(--interactive-hover);
-		color: var(--text-normal);
-	}
-
-	.view-toggle-btn.active {
-		background: var(--interactive-accent);
-		color: var(--text-on-accent);
 	}
 
 	.valuation-method-selector select {

--- a/src/ui/partials/dashboard/IncomeStatementTab.svelte
+++ b/src/ui/partials/dashboard/IncomeStatementTab.svelte
@@ -1,0 +1,800 @@
+<script lang="ts">
+	import { writable, type Writable } from 'svelte/store';
+	import type { IncomeStatementController, IncomeStatementState } from '../../../controllers/IncomeStatementController';
+	import type { AccountItem } from '../../../controllers/BalanceSheetController';
+	import { Logger } from '../../../utils/logger';
+	import SunburstChart from '../../common/SunburstChart.svelte';
+	import ChartComponent from '../../common/ChartComponent.svelte';
+
+	// Chart selector
+	let selectedChart: 'trend' | 'total' = 'trend';
+	// Sub-selector for sunburst section
+	let selectedTotalSection: 'income' | 'expenses' = 'income';
+
+	// --- Receive the controller ---
+	export let controller: IncomeStatementController;
+
+	// --- Placeholder state & store subscription ---
+	const placeholderState: Writable<IncomeStatementState> = writable({
+		isLoading: true, error: null, income: [], expenses: [],
+		totalIncome: 0, totalExpenses: 0, netProfit: 0, currency: 'USD',
+		hasUnconvertedCommodities: false, unconvertedWarning: null, valuationMethod: 'convert',
+		chartConfig: null, chartError: null, chartLoading: false, chartInterval: 'month',
+	});
+	$: stateStore = controller ? controller.state : placeholderState;
+	$: state = $stateStore;
+
+	// Indentation helper
+	function getIndentation(level: number): string {
+		return '\u00A0'.repeat(level * 4);
+	}
+
+	function getAccountClass(item: AccountItem): string {
+		return `account-row level-${item.level} ${item.isCategory ? 'category' : 'leaf'}`;
+	}
+
+	function hasOtherCurrencies(accounts: AccountItem[]): boolean {
+		return accounts.some(item => item.otherCurrencies && item.otherCurrencies.trim() !== '');
+	}
+
+	$: showOtherCurrenciesColumn = state.income && state.expenses &&
+		(hasOtherCurrencies(state.income) || hasOtherCurrencies(state.expenses));
+
+	// Valuation method change
+	async function handleValuationMethodChange(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		const method = target.value as 'convert' | 'cost' | 'units';
+		if (controller) {
+			await controller.setValuationMethod(method);
+		}
+	}
+
+	// Collapsible hierarchy
+	let collapsedAccounts = new Set<string>();
+
+	function toggleCollapse(account: string, event?: MouseEvent) {
+		if (event) event.stopPropagation();
+		const newSet = new Set(collapsedAccounts);
+		if (newSet.has(account)) {
+			newSet.delete(account);
+		} else {
+			newSet.add(account);
+		}
+		collapsedAccounts = newSet;
+	}
+
+	function isCollapsed(account: string): boolean {
+		return collapsedAccounts.has(account);
+	}
+
+	function shouldShowRow(item: AccountItem, collapsed: Set<string>): boolean {
+		if (item.level === 0) return true;
+		const parts = item.account.split(':');
+		for (let i = 1; i < parts.length; i++) {
+			const parentPath = parts.slice(0, i).join(':');
+			if (collapsed.has(parentPath)) return false;
+		}
+		return true;
+	}
+
+	$: visibleIncome = state.income ? state.income.filter(item => shouldShowRow(item, collapsedAccounts)) : [];
+	$: visibleExpenses = state.expenses ? state.expenses.filter(item => shouldShowRow(item, collapsedAccounts)) : [];
+
+	function handleRefresh() {
+		if (controller) controller.loadData();
+	}
+
+	function handleIntervalChange(interval: 'month' | 'week') {
+		if (controller && state.chartInterval !== interval) {
+			controller.setChartInterval(interval);
+		}
+	}
+
+	// Net profit sign helper
+	function netProfitClass(val: number): string {
+		return val >= 0 ? 'positive' : 'negative';
+	}
+</script>
+
+<div class="income-statement-container">
+	<!-- Header -->
+	<div class="income-statement-header">
+		<h2>Income Statement</h2>
+		<div class="header-controls">
+			<button
+				on:click={handleRefresh}
+				disabled={state.isLoading}
+				class="refresh-button"
+				title="Refresh data"
+			>
+				{#if state.isLoading}
+					<svg class="loading-spinner" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M21 12a9 9 0 11-6.219-8.56"/>
+					</svg>
+					Refreshing...
+				{:else}
+					<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M3 12a9 9 0 013.5-7.1"/>
+						<path d="M20.5 5.5a9 9 0 01.5 6.5"/>
+						<path d="M3 12a9 9 0 006.5 8.1"/>
+						<path d="M20.5 18.5a9 9 0 01-6.5-5.5"/>
+					</svg>
+					Refresh
+				{/if}
+			</button>
+		</div>
+	</div>
+
+	{#if state.isLoading}
+		<p>Loading data...</p>
+	{:else if state.error}
+		<p class="error-message">{state.error}</p>
+	{:else}
+		<!-- Multi-currency warning -->
+		{#if state.hasUnconvertedCommodities && state.unconvertedWarning}
+			<div class="warning-banner">
+				<span class="warning-icon">⚠️</span>
+				<span class="warning-text">{state.unconvertedWarning}</span>
+			</div>
+		{/if}
+
+		<!-- Chart Area -->
+		<div class="chart-area">
+			<div class="chart-area-header">
+				<div class="chart-selector" role="group" aria-label="Select chart">
+					<button
+						class="chart-selector-btn"
+						class:active={selectedChart === 'trend'}
+						on:click={() => (selectedChart = 'trend')}
+						aria-pressed={selectedChart === 'trend'}
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<rect x="3" y="12" width="4" height="9"/><rect x="10" y="7" width="4" height="14"/><rect x="17" y="3" width="4" height="18"/>
+						</svg>
+						Net Profit Trend
+					</button>
+					<button
+						class="chart-selector-btn"
+						class:active={selectedChart === 'total'}
+						on:click={() => (selectedChart = 'total')}
+						aria-pressed={selectedChart === 'total'}
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<circle cx="12" cy="12" r="3"/>
+							<circle cx="12" cy="12" r="7"/>
+							<circle cx="12" cy="12" r="11"/>
+						</svg>
+						Total
+					</button>
+				</div>
+
+				{#if selectedChart === 'trend'}
+					<div class="interval-toggle">
+						<button
+							class:active={state.chartInterval === 'month'}
+							on:click={() => handleIntervalChange('month')}
+							disabled={state.chartLoading}
+						>Monthly</button>
+						<button
+							class:active={state.chartInterval === 'week'}
+							on:click={() => handleIntervalChange('week')}
+							disabled={state.chartLoading}
+						>Weekly</button>
+					</div>
+				{:else if selectedChart === 'total'}
+					<div class="section-toggle">
+						<button
+							class:active={selectedTotalSection === 'income'}
+							on:click={() => (selectedTotalSection = 'income')}
+						>Income</button>
+						<button
+							class:active={selectedTotalSection === 'expenses'}
+							on:click={() => (selectedTotalSection = 'expenses')}
+						>Expenses</button>
+					</div>
+				{/if}
+			</div>
+
+			{#if selectedChart === 'trend'}
+				<div class="trend-chart-container">
+					{#if state.chartError}
+						<p class="error-message">Chart Error: {state.chartError}</p>
+					{:else if state.chartLoading}
+						<p class="chart-loading">Loading chart...</p>
+					{:else if state.chartConfig}
+						<ChartComponent config={state.chartConfig} height="300px"/>
+					{:else}
+						<p class="chart-loading">Not enough data to display chart.</p>
+					{/if}
+				</div>
+			{:else if selectedChart === 'total'}
+				{#if selectedTotalSection === 'income'}
+					<!-- Income: expect negative (credit accounts). Pass as assets→green, with assetsExpectNegative -->
+					<SunburstChart
+						title="Income"
+						assets={state.income}
+						liabilities={[]}
+						equity={[]}
+						currency={state.currency}
+						totalAssets={state.totalIncome}
+						totalLiabilities={0}
+						totalEquity={0}
+						assetsLabel="Income"
+						assetsExpectNegative={true}
+					/>
+				{:else}
+					<!-- Expenses: expect positive (debit accounts). Pass as liabilities→red, with liabilitiesExpectNegative=false -->
+					<SunburstChart
+						title="Expenses"
+						assets={[]}
+						liabilities={state.expenses}
+						equity={[]}
+						currency={state.currency}
+						totalAssets={0}
+						totalLiabilities={state.totalExpenses}
+						totalEquity={0}
+						liabilitiesLabel="Expenses"
+						liabilitiesExpectNegative={false}
+					/>
+				{/if}
+			{/if}
+		</div>
+
+		<!-- Income Statement Table -->
+		<div class="income-statement-section">
+			<div class="income-statement-section-header">
+				<h3>Income Statement</h3>
+				<div class="valuation-method-selector">
+					<label for="is-valuation-method">Valuation:</label>
+					<select
+						id="is-valuation-method"
+						value={state.valuationMethod || 'convert'}
+						on:change={handleValuationMethodChange}
+					>
+						<option value="convert">Market Value (Convert to {state.currency})</option>
+						<option value="cost">At Cost</option>
+						<option value="units">Units</option>
+					</select>
+				</div>
+			</div>
+
+			<div class="income-statement-grid">
+				<!-- Income Column -->
+				<div class="column">
+					<h4>Income</h4>
+					<table class="beancount-table">
+						<thead>
+							<tr class="header-row">
+								<th class="account-header">Account</th>
+								<th class="amount-header">{state.currency}</th>
+								{#if showOtherCurrenciesColumn}
+									<th class="other-currencies-header">Other Currencies</th>
+								{/if}
+							</tr>
+						</thead>
+						<tbody>
+							{#each visibleIncome as item}
+								<tr class={getAccountClass(item)}>
+									<td class="account-name"
+										on:click={(e) => item.isCategory && toggleCollapse(item.account, e)}
+										style="cursor: {item.isCategory ? 'pointer' : 'default'};">
+										{#if item.isCategory}
+											<span class="collapse-icon">{isCollapsed(item.account) ? '▶' : '▼'}</span>
+										{/if}
+										{getIndentation(item.level)}{item.displayName}
+									</td>
+									<td class="align-right amount-cell" class:category-amount={item.isCategory}>
+										{item.amount}
+									</td>
+									{#if showOtherCurrenciesColumn}
+										<td class="align-right other-currencies-cell">
+											{item.otherCurrencies || ''}
+										</td>
+									{/if}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+					<div class="section-total">
+						<span>Total Income</span>
+						<span class="total-amount">{state.totalIncome.toFixed(2)} {state.currency}</span>
+					</div>
+				</div>
+
+				<!-- Expenses Column -->
+				<div class="column">
+					<h4>Expenses</h4>
+					<table class="beancount-table">
+						<thead>
+							<tr class="header-row">
+								<th class="account-header">Account</th>
+								<th class="amount-header">{state.currency}</th>
+								{#if showOtherCurrenciesColumn}
+									<th class="other-currencies-header">Other Currencies</th>
+								{/if}
+							</tr>
+						</thead>
+						<tbody>
+							{#each visibleExpenses as item}
+								<tr class={getAccountClass(item)}>
+									<td class="account-name"
+										on:click={(e) => item.isCategory && toggleCollapse(item.account, e)}
+										style="cursor: {item.isCategory ? 'pointer' : 'default'};">
+										{#if item.isCategory}
+											<span class="collapse-icon">{isCollapsed(item.account) ? '▶' : '▼'}</span>
+										{/if}
+										{getIndentation(item.level)}{item.displayName}
+									</td>
+									<td class="align-right amount-cell" class:category-amount={item.isCategory}>
+										{item.amount}
+									</td>
+									{#if showOtherCurrenciesColumn}
+										<td class="align-right other-currencies-cell">
+											{item.otherCurrencies || ''}
+										</td>
+									{/if}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+					<div class="section-total">
+						<span>Total Expenses</span>
+						<span class="total-amount">{state.totalExpenses.toFixed(2)} {state.currency}</span>
+					</div>
+				</div>
+			</div>
+
+			<!-- Net Profit Summary -->
+			<div class="net-profit-row">
+				<span class="net-profit-label">Net Profit</span>
+				<span class="net-profit-value {netProfitClass(state.netProfit)}">
+					{state.netProfit.toFixed(2)} {state.currency}
+				</span>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.income-statement-container {
+		padding: var(--size-4-4);
+		width: 100%;
+		overflow-x: auto;
+	}
+
+	.income-statement-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--size-4-6);
+		flex-wrap: wrap;
+		gap: var(--size-4-4);
+	}
+
+	.income-statement-header h2 {
+		margin: 0;
+		flex: 1;
+	}
+
+	.header-controls {
+		display: flex;
+		gap: var(--size-4-4);
+		align-items: center;
+	}
+
+	/* Refresh button */
+	.refresh-button {
+		display: flex;
+		align-items: center;
+		gap: var(--size-4-2);
+		padding: var(--size-4-2) var(--size-4-3);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		background: var(--interactive-normal);
+		color: var(--text-normal);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: all 0.2s ease;
+		white-space: nowrap;
+	}
+
+	.refresh-button:hover:not(:disabled) {
+		background: var(--interactive-hover);
+		border-color: var(--interactive-accent);
+	}
+
+	.refresh-button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	@keyframes spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+
+	.loading-spinner {
+		animation: spin 1s linear infinite;
+	}
+
+	/* Chart area */
+	.chart-area {
+		margin-bottom: var(--size-4-8);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: var(--size-4-4);
+		background: var(--background-secondary);
+	}
+
+	.chart-area-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--size-4-4);
+		flex-wrap: wrap;
+		gap: var(--size-4-2);
+	}
+
+	.chart-selector {
+		display: flex;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		overflow: hidden;
+	}
+
+	.chart-selector-btn {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 4px 12px;
+		border: none;
+		background: var(--interactive-normal);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.chart-selector-btn:not(:last-child) {
+		border-right: 1px solid var(--background-modifier-border);
+	}
+
+	.chart-selector-btn:hover {
+		background: var(--interactive-hover);
+		color: var(--text-normal);
+	}
+
+	.chart-selector-btn.active {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+
+	.interval-toggle,
+	.section-toggle {
+		display: flex;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		overflow: hidden;
+	}
+
+	.interval-toggle button,
+	.section-toggle button {
+		padding: var(--size-4-1) var(--size-4-3);
+		background: var(--interactive-normal);
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: background-color 0.15s, color 0.15s;
+	}
+
+	.interval-toggle button:not(:last-child),
+	.section-toggle button:not(:last-child) {
+		border-right: 1px solid var(--background-modifier-border);
+	}
+
+	.interval-toggle button.active,
+	.section-toggle button.active {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+
+	.interval-toggle button:hover:not(.active):not(:disabled),
+	.section-toggle button:hover:not(.active) {
+		background: var(--interactive-hover);
+		color: var(--text-normal);
+	}
+
+	.interval-toggle button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.trend-chart-container {
+		height: 320px;
+		position: relative;
+	}
+
+	/* Income Statement section */
+	.income-statement-section {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: var(--size-4-4);
+	}
+
+	.income-statement-section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--size-4-4);
+		flex-wrap: wrap;
+		gap: var(--size-4-2);
+	}
+
+	.income-statement-section-header h3 {
+		margin: 0;
+		color: var(--text-normal);
+		font-size: var(--font-ui-larger);
+	}
+
+	.valuation-method-selector {
+		display: flex;
+		align-items: center;
+		gap: var(--size-4-2);
+	}
+
+	.valuation-method-selector label {
+		font-size: 0.9em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+
+	.valuation-method-selector select {
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		padding: var(--size-4-1) var(--size-4-2);
+		color: var(--text-normal);
+		font-size: 0.9em;
+		min-width: 200px;
+	}
+
+	.valuation-method-selector select:focus {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 1px;
+	}
+
+	.income-statement-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--size-4-8);
+		align-items: start;
+		overflow-x: auto;
+	}
+
+	@media (max-width: 1200px) {
+		.income-statement-grid {
+			grid-template-columns: 1fr;
+			gap: var(--size-4-6);
+		}
+
+		.income-statement-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-4-3);
+		}
+	}
+
+	.column {
+		min-width: 0;
+		overflow-x: auto;
+	}
+
+	.column h4 {
+		margin-top: 0;
+		color: var(--text-normal);
+		border-bottom: 1px solid var(--background-modifier-border);
+		padding-bottom: var(--size-4-2);
+	}
+
+	/* Warning banner */
+	.warning-banner {
+		background-color: var(--background-modifier-form-field);
+		border: 1px solid var(--color-orange);
+		border-radius: var(--radius-s);
+		padding: var(--size-4-2) var(--size-4-3);
+		margin-bottom: var(--size-4-4);
+		display: flex;
+		align-items: center;
+		gap: var(--size-4-2);
+	}
+
+	.warning-icon {
+		font-size: 1.1em;
+		color: var(--color-orange);
+	}
+
+	.warning-text {
+		color: var(--text-muted);
+		font-size: 0.9em;
+		line-height: 1.4;
+	}
+
+	/* Table */
+	.beancount-table {
+		width: 100%;
+		border-collapse: collapse;
+		table-layout: fixed;
+		min-width: 300px;
+	}
+
+	.beancount-table thead {
+		background-color: var(--background-modifier-form-field);
+		border-bottom: 2px solid var(--background-modifier-border);
+	}
+
+	.header-row th {
+		padding: var(--size-4-3);
+		font-weight: 600;
+		color: var(--text-normal);
+		text-align: left;
+		border-bottom: 2px solid var(--background-modifier-border);
+		word-wrap: break-word;
+	}
+
+	.account-header {
+		width: 50%;
+		min-width: 140px;
+	}
+
+	.amount-header {
+		width: 25%;
+		text-align: right !important;
+		min-width: 100px;
+	}
+
+	.other-currencies-header {
+		width: 25%;
+		text-align: right !important;
+		min-width: 120px;
+		color: var(--text-muted);
+	}
+
+	.beancount-table td,
+	.beancount-table th {
+		padding: var(--size-4-2) var(--size-4-3);
+		border-bottom: 1px solid var(--background-secondary);
+		vertical-align: top;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+	}
+
+	.account-name {
+		font-family: var(--font-interface);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 180px;
+		width: 50%;
+	}
+
+	.collapse-icon {
+		display: inline-block;
+		width: 12px;
+		margin-right: 4px;
+		font-size: 0.8em;
+		color: var(--text-muted);
+		user-select: none;
+	}
+
+	.amount-cell {
+		font-family: var(--font-monospace);
+		white-space: nowrap;
+		width: 25%;
+		text-align: right;
+	}
+
+	.category-amount {
+		font-weight: 600;
+	}
+
+	.align-right {
+		text-align: right;
+	}
+
+	.other-currencies-cell {
+		font-family: var(--font-monospace);
+		font-size: 0.8em;
+		white-space: pre-line;
+		color: var(--text-muted);
+		text-align: right;
+	}
+
+	/* Account row styles */
+	:global(.account-row) {
+		transition: background-color 0.1s ease;
+	}
+
+	:global(.account-row:hover) {
+		background-color: var(--background-modifier-hover);
+	}
+
+	:global(.account-row.category) {
+		background-color: var(--background-secondary);
+	}
+
+	:global(.account-row.level-0) {
+		font-weight: 700;
+		font-size: 1.05em;
+	}
+
+	:global(.account-row.level-1) {
+		font-weight: 500;
+	}
+
+	/* Section totals */
+	.section-total {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--size-4-2) var(--size-4-3);
+		margin-top: var(--size-4-2);
+		border-top: 2px solid var(--background-modifier-border);
+		font-weight: 600;
+		background: var(--background-secondary);
+		border-radius: 0 0 var(--radius-s) var(--radius-s);
+	}
+
+	.total-amount {
+		font-family: var(--font-monospace);
+	}
+
+	.total-amount.positive {
+		color: var(--color-green);
+	}
+
+	/* Net profit row */
+	.net-profit-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--size-4-3) var(--size-4-4);
+		margin-top: var(--size-4-4);
+		border: 2px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		background: var(--background-secondary);
+		font-weight: 700;
+		font-size: 1.05em;
+	}
+
+	.net-profit-label {
+		color: var(--text-normal);
+	}
+
+	.net-profit-value {
+		font-family: var(--font-monospace);
+		font-size: 1.1em;
+	}
+
+	.net-profit-value.positive {
+		color: var(--color-green);
+	}
+
+	.net-profit-value.negative {
+		color: var(--color-red);
+	}
+
+	.error-message {
+		color: var(--color-red);
+		padding: var(--size-4-3);
+		border: 1px solid var(--color-red);
+		border-radius: var(--radius-s);
+		background: var(--background-modifier-error);
+	}
+
+	.chart-loading {
+		color: var(--text-muted);
+		text-align: center;
+		padding: var(--size-4-8);
+	}
+</style>

--- a/src/ui/partials/dashboard/OverviewTab.svelte
+++ b/src/ui/partials/dashboard/OverviewTab.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import CardComponent from '../../common/CardComponent.svelte';
-	import ChartComponent from '../../common/ChartComponent.svelte';
 	import type { OverviewController } from '../../../controllers/OverviewController';
-	import type { ChartConfiguration } from 'chart.js/auto';
 	import { writable, type Writable } from 'svelte/store'; // Import writable
 	import type { OverviewState } from '../../../controllers/OverviewController'; // Import the State type
 
@@ -19,10 +17,6 @@
 		monthlyIncome: '0.00 USD',
 		monthlyExpenses: '0.00 USD',
 		savingsRate: '0%',
-		chartConfig: null,
-		chartError: null,
-		chartLoading: false,
-		chartInterval: 'month',
 		currency: 'USD',
 	});
 
@@ -38,12 +32,6 @@
 	function handleRefresh() {
 		if (controller) {
 			controller.loadData();
-		}
-	}
-
-	function handleIntervalChange(interval: 'month' | 'week') {
-		if (controller && state.chartInterval !== interval) {
-			controller.setChartInterval(interval);
 		}
 	}
 	// -----------------------
@@ -93,32 +81,6 @@
 			<CardComponent label="Monthly Income" value={state.monthlyIncome} comparison="Current month earnings" />
 			<CardComponent label="Monthly Expenses" value={state.monthlyExpenses} comparison="Current month spending" />
 			<CardComponent label="Savings Rate" value={state.savingsRate} comparison="Income minus expenses" />
-		</div>
-		
-		<div class="chart-container">
-			<div class="chart-header">
-				<div class="interval-toggle">
-					<button
-						class:active={state.chartInterval === 'month'}
-						on:click={() => handleIntervalChange('month')}
-						disabled={state.chartLoading}
-					>Monthly</button>
-					<button
-						class:active={state.chartInterval === 'week'}
-						on:click={() => handleIntervalChange('week')}
-						disabled={state.chartLoading}
-					>Weekly</button>
-				</div>
-			</div>
-			{#if state.chartError}
-				<p class="error-message">Chart Error: {state.chartError}</p>
-			{:else if state.chartLoading}
-				<p class="chart-loading">Loading chart...</p>
-			{:else if state.chartConfig}
-				<ChartComponent config={state.chartConfig} height="300px"/>
-			{:else if !state.isLoading}
-				<p>Not enough data to display chart.</p>
-			{/if}
 		</div>
 	{/if}
 </div>
@@ -199,52 +161,4 @@
 	}
 	
 	.error-message { color: var(--text-error); }
-	.chart-loading { color: var(--text-muted); font-size: var(--font-ui-small); text-align: center; padding: var(--size-4-8) 0; }
-	.chart-container {
-		margin-top: var(--size-4-8);
-		height: 360px;
-		position: relative;
-	}
-
-	.chart-header {
-		display: flex;
-		justify-content: flex-end;
-		margin-bottom: var(--size-4-2);
-	}
-
-	.interval-toggle {
-		display: flex;
-		border: 1px solid var(--background-modifier-border);
-		border-radius: var(--radius-s);
-		overflow: hidden;
-	}
-
-	.interval-toggle button {
-		padding: var(--size-4-1) var(--size-4-3);
-		background: var(--interactive-normal);
-		border: none;
-		color: var(--text-muted);
-		cursor: pointer;
-		font-size: var(--font-ui-small);
-		transition: background-color 0.15s, color 0.15s;
-	}
-
-	.interval-toggle button:not(:last-child) {
-		border-right: 1px solid var(--background-modifier-border);
-	}
-
-	.interval-toggle button.active {
-		background: var(--interactive-accent);
-		color: var(--text-on-accent);
-	}
-
-	.interval-toggle button:hover:not(.active):not(:disabled) {
-		background: var(--interactive-hover);
-		color: var(--text-normal);
-	}
-
-	.interval-toggle button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
 </style>

--- a/src/ui/views/dashboard/UnifiedDashboardView.svelte
+++ b/src/ui/views/dashboard/UnifiedDashboardView.svelte
@@ -7,18 +7,21 @@
     import BalanceSheetTab from '../../partials/dashboard/BalanceSheetTab.svelte';
     import CommoditiesTab from '../../partials/dashboard/CommoditiesTab.svelte';
     import JournalTab from '../../partials/dashboard/JournalTab.svelte';
+    import IncomeStatementTab from '../../partials/dashboard/IncomeStatementTab.svelte';
 
     // Types
     import type { OverviewController } from '../../../controllers/OverviewController';
     import type { TransactionController } from '../../../controllers/TransactionController';
     import type { BalanceSheetController } from '../../../controllers/BalanceSheetController';
     import type { CommoditiesController } from '../../../controllers/CommoditiesController';
+    import type { IncomeStatementController } from '../../../controllers/IncomeStatementController';
 
     // Props
     export let overviewController: OverviewController;
     export let transactionController: TransactionController;
     export let balanceSheetController: BalanceSheetController;
     export let commoditiesController: CommoditiesController;
+    export let incomeStatementController: IncomeStatementController;
     export let journalStore: any;
     export let plugin: any = null; // Add plugin prop
 
@@ -29,6 +32,7 @@
         { id: 'transactions', label: 'Transactions' },
         { id: 'journal', label: 'Journal' },
         { id: 'balancesheet', label: 'Accounts & Balances' },
+        { id: 'incomestatement', label: 'Income Statement' },
         { id: 'commodities', label: 'Commodities' }
     ];
 </script>
@@ -57,6 +61,8 @@
             <JournalTab store={journalStore} plugin={plugin} />
         {:else if activeTab === 'balancesheet'}
             <BalanceSheetTab controller={balanceSheetController} />
+        {:else if activeTab === 'incomestatement'}
+            <IncomeStatementTab controller={incomeStatementController} />
         {:else if activeTab === 'commodities'}
             <CommoditiesTab controller={commoditiesController} on:openCommodity on:addCommodity />
         {/if}

--- a/src/ui/views/dashboard/unified-dashboard-view.ts
+++ b/src/ui/views/dashboard/unified-dashboard-view.ts
@@ -11,6 +11,7 @@ import { OverviewController } from '../../../controllers/OverviewController';
 import { TransactionController } from '../../../controllers/TransactionController';
 import { BalanceSheetController } from '../../../controllers/BalanceSheetController';
 import { CommoditiesController } from '../../../controllers/CommoditiesController';
+import { IncomeStatementController } from '../../../controllers/IncomeStatementController';
 // JournalController is replaced by plugin.journalStore
 // -----------------------------
 
@@ -25,6 +26,7 @@ export class UnifiedDashboardView extends ItemView {
 	transactionController: TransactionController;
 	balanceSheetController: BalanceSheetController;
 	commoditiesController: CommoditiesController;
+	incomeStatementController: IncomeStatementController;
 
 	constructor(leaf: WorkspaceLeaf, plugin: BeancountPlugin) {
 		super(leaf);
@@ -34,6 +36,7 @@ export class UnifiedDashboardView extends ItemView {
 		this.transactionController = new TransactionController(this.plugin);
 		this.balanceSheetController = new BalanceSheetController(this.plugin);
 		this.commoditiesController = new CommoditiesController(this.plugin);
+		this.incomeStatementController = new IncomeStatementController(this.plugin);
 	}
 
 	getViewType(): string { return UNIFIED_DASHBOARD_VIEW_TYPE; }
@@ -47,6 +50,7 @@ export class UnifiedDashboardView extends ItemView {
 				this.overviewController.loadData(),
 				this.transactionController.loadFilterData(),
 				this.balanceSheetController.loadData(),
+				this.incomeStatementController.loadData(),
 				this.commoditiesController.loadData(),
 				this.plugin.journalStore.refresh() // Use new store
 			]);
@@ -66,6 +70,7 @@ export class UnifiedDashboardView extends ItemView {
 				overviewController: this.overviewController,
 				transactionController: this.transactionController,
 				balanceSheetController: this.balanceSheetController,
+				incomeStatementController: this.incomeStatementController,
 				commoditiesController: this.commoditiesController,
 				journalStore: this.plugin.journalStore, // Pass store instead of controller
 				plugin: this.plugin // Pass plugin instance
@@ -94,6 +99,7 @@ export class UnifiedDashboardView extends ItemView {
 		this.transactionController.loadFilterData(); // Load filter dropdown data
 		this.transactionController.handleFilterChange({}); // Load initial transactions
 		this.balanceSheetController.loadData();
+		this.incomeStatementController.loadData();
 	}
 
 	async onClose() {


### PR DESCRIPTION
Implemented refactoring of the "Overview" and "Accounts and Balances" tab + added new tab "Income Statement"

### Dashboard Updates

* Overview tab simplified to **KPIs only** (Net Worth, Income, Expenses, Savings Rate)
* **Net Worth Trend chart** moved to *Accounts & Balances*

---

### Accounts & Balances

* Added **Balances mode** with section selector: *Assets | Liabilities | Equity*
* Each section now renders its **own Sunburst chart**

---

### Sunburst Improvements

* Section-aware titles (no more “All Accounts”)
* Fixed incorrect totals for Equity and Liabilities
* **Unexpected-sign accounts** now shown with **striped overlay** (instead of color change)
* Added legend note: *“Stripes = unexpected sign”*

---

### 🆕 Income Statement Tab

* New tab with **income vs expenses breakdown**

**Charts**

* Net Profit Trend (green = profit, red = loss, Monthly/Weekly toggle)
* Sunburst breakdown for Income or Expenses

**Table**

* Two-column layout (Income | Expenses)
* Collapsible account hierarchy
* Valuation modes: *Market Value, Cost, Units*
* Net Profit summary (green/red)
* Multi-currency warning + Refresh button

---

### Data Convention

* Uses **raw Beancount signs**:

  * Income = negative
  * Expenses = positive

---
