### PR TITLE
[Refactor] Add output format selector to BQL code blocks (#111)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { Plugin } from 'obsidian';
 import { BeancountSettingTab, type BeancountPluginSettings, DEFAULT_SETTINGS } from './settings';
 import { BeancountView, BEANCOUNT_VIEW_TYPE } from './ui/views/sidebar/sidebar-view';
 import { UnifiedTransactionModal } from './ui/modals/UnifiedTransactionModal';
-import { runQuery } from './utils/index';
+import { runQuery, type BQLFormat } from './utils/index';
 import { UnifiedDashboardView, UNIFIED_DASHBOARD_VIEW_TYPE } from './ui/views/dashboard/unified-dashboard-view';
 import { BQLCodeBlockProcessor } from './ui/markdown/BQLCodeBlockProcessor';
 import { InlineBQLProcessor } from './ui/markdown/InlineBQLProcessor';
@@ -218,10 +218,11 @@ export default class BeancountPlugin extends Plugin {
 	/**
 	 * Public wrapper for running BQL queries (used by views and controllers).
 	 * @param {string} query - The BQL query.
-	 * @returns {Promise<string>} The CSV output.
+	 * @param {BQLFormat} [format='csv'] - Output format (csv, text, html).
+	 * @returns {Promise<string>} The raw output in the requested format.
 	 */
-	public runQuery = (query: string): Promise<string> => {
-		return runQuery(this, query);
+	public runQuery = (query: string, format: BQLFormat = 'csv'): Promise<string> => {
+		return runQuery(this, query, undefined, format);
 	}
 
 	// Helper method to get dashboard refresh callback

--- a/src/ui/markdown/BQLCodeBlockProcessor.ts
+++ b/src/ui/markdown/BQLCodeBlockProcessor.ts
@@ -2,6 +2,7 @@
 
 import type { MarkdownPostProcessorContext } from 'obsidian';
 import type BeancountPlugin from '../../main';
+import type { BQLFormat } from '../../utils/queryRunner';
 
 export class BQLCodeBlockProcessor {
 	private plugin: BeancountPlugin;
@@ -80,6 +81,24 @@ export class BQLCodeBlockProcessor {
 			
 			if (showTools) {
 				controls = header.createEl('div', { cls: 'bql-query-controls' });
+
+				// Format selector
+				const formatSelect = controls.createEl('select', { cls: 'bql-format-select', title: 'Output format' }) as HTMLSelectElement;
+				const formatOptions: { value: BQLFormat; label: string }[] = [
+					{ value: 'csv', label: 'Table' },
+					{ value: 'text', label: 'Text' },
+					{ value: 'beancount', label: 'Beancount' },
+				];
+				formatOptions.forEach(opt => {
+					const option = formatSelect.createEl('option', { text: opt.label }) as HTMLOptionElement;
+					option.value = opt.value;
+				});
+				(container as any)._bqlFormat = 'csv' as BQLFormat;
+				formatSelect.value = 'csv';
+				formatSelect.addEventListener('change', () => {
+					(container as any)._bqlFormat = formatSelect.value as BQLFormat;
+					executeQuery();
+				});
 				
 				refreshBtn = controls.createEl('button', { 
 					text: '⟳', 
@@ -96,7 +115,7 @@ export class BQLCodeBlockProcessor {
 				exportBtn = controls.createEl('button', { 
 					text: '📤', 
 					cls: 'bql-export-btn',
-					title: 'Export as CSV'
+					title: 'Export results'
 				});
 			}
 		}
@@ -129,13 +148,14 @@ export class BQLCodeBlockProcessor {
 					loadingEl.textContent = 'Loading...';
 				}
 				
-				// Execute the query
-				const csvResult = await this.plugin.runQuery(query);
+				// Execute the query with the currently selected format
+				const currentFormat: BQLFormat = (container as any)._bqlFormat ?? 'csv';
+				const queryResult = await this.plugin.runQuery(query, currentFormat);
 				
 				// Clear loading and show results
 				resultArea.empty();
 				
-				if (!csvResult || csvResult.trim() === '') {
+				if (!queryResult || queryResult.trim() === '') {
 					resultArea.createEl('div', { 
 						text: 'No results returned', 
 						cls: 'bql-no-results' 
@@ -143,22 +163,25 @@ export class BQLCodeBlockProcessor {
 					return;
 				}
 				
-				// Parse CSV and create table
-				const { table, error } = this.createTableFromCSV(csvResult);
-				
-				if (error) {
-					// Create collapsible error with short summary
-					this.createCollapsibleError(resultArea, 'Error parsing results', error);
-					
-					// Show raw results as fallback
-					const rawEl = resultArea.createEl('pre', { cls: 'bql-raw-result' });
-					rawEl.textContent = csvResult;
-				} else if (table) {
-					resultArea.appendChild(table);
+				if (currentFormat === 'csv') {
+					// Parse CSV and create table
+					const { table, error } = this.createTableFromCSV(queryResult);
+					if (error) {
+						this.createCollapsibleError(resultArea, 'Error parsing results', error);
+						const rawEl = resultArea.createEl('pre', { cls: 'bql-raw-result' });
+						rawEl.textContent = queryResult;
+					} else if (table) {
+						resultArea.appendChild(table);
+					}
+				} else {
+					// text and beancount formats — render as preformatted text
+					const preEl = resultArea.createEl('pre', { cls: 'bql-text-result' });
+					preEl.textContent = queryResult;
 				}
 				
 				// Store result for copy/export functions
-				(container as any)._lastResult = csvResult;
+				(container as any)._lastResult = queryResult;
+				(container as any)._lastFormat = currentFormat;
 				
 			} catch (error) {
 				// Show collapsible error message
@@ -187,8 +210,11 @@ export class BQLCodeBlockProcessor {
 		if (exportBtn) {
 			exportBtn.addEventListener('click', () => {
 				const result = (container as any)._lastResult;
+				const fmt: BQLFormat = (container as any)._lastFormat ?? 'csv';
 				if (result) {
-					this.downloadCSV(result, 'bql-query-result.csv');
+					const ext = fmt === 'csv' ? 'csv' : 'txt';
+					const mimeType = fmt === 'csv' ? 'text/csv;charset=utf-8;' : 'text/plain;charset=utf-8;';
+					this.downloadFile(result, `bql-query-result.${ext}`, mimeType);
 					exportBtn.textContent = '✓';
 					setTimeout(() => exportBtn.textContent = '📤', 1000);
 				}
@@ -323,10 +349,9 @@ export class BQLCodeBlockProcessor {
 		return /^[+-]?[\d,]*\.?\d+\s*[A-Z]*$/.test(str.trim());
 	}
 	
-	private downloadCSV(csvContent: string, filename: string) {
-		const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+	private downloadFile(content: string, filename: string, mimeType: string) {
+		const blob = new Blob([content], { type: mimeType });
 		const link = document.createElement('a');
-		
 		if (link.download !== undefined) {
 			const url = URL.createObjectURL(blob);
 			link.setAttribute('href', url);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,7 +13,7 @@
 //   journal.ts      – getTransactionEntries, getBalanceEntries, getNoteEntries
 //   directives.ts   – all create/update/delete write operations + generateTransactionText + validateCommodityLocation
 
-export { runQuery } from './queryRunner';
+export { runQuery, type BQLFormat } from './queryRunner';
 export { convertWindowsPathToWsl, convertWslPathToWindows, atomicFileWrite, createBackupFile } from './fileEditor';
 export {
 	parseSingleValue,

--- a/src/utils/queryRunner.ts
+++ b/src/utils/queryRunner.ts
@@ -8,16 +8,20 @@ import { getMainLedgerPath } from './structuredLayout';
 import { convertWindowsPathToWsl } from './fileEditor';
 import { Logger } from './logger';
 
+/** Output formats supported by bean-query's `-f` flag. */
+export type BQLFormat = 'csv' | 'text' | 'beancount';
+
 /**
  * Executes a Beancount query (BQL) against the configured ledger file.
  *
  * @param {BeancountPlugin} plugin  - The plugin instance (for settings).
  * @param {string}          query   - The BQL query string.
  * @param {string}         [filepath] - Optional path to a specific file. Defaults to the main ledger.
- * @returns {Promise<string>} The CSV output of the query.
+ * @param {BQLFormat}      [format='csv'] - Output format passed to bean-query via -f flag.
+ * @returns {Promise<string>} The raw output of the query in the requested format.
  * @throws {Error} If the query fails or command / path is not configured.
  */
-export function runQuery(plugin: BeancountPlugin, query: string, filepath?: string): Promise<string> {
+export function runQuery(plugin: BeancountPlugin, query: string, filepath?: string, format: BQLFormat = 'csv'): Promise<string> {
     return new Promise((resolve, reject) => {
         const filePath = filepath || getMainLedgerPath(plugin);
         const commandName = plugin.settings.beancountCommand;
@@ -32,7 +36,7 @@ export function runQuery(plugin: BeancountPlugin, query: string, filepath?: stri
 
         // Escape double-quotes in query for shell execution
         const escapedQuery = query.replace(/"/g, '\\"');
-        const command = `${commandName} -q -f csv "${queryFilePath}" "${escapedQuery}"`;
+        const command = `${commandName} -q -f ${format} "${queryFilePath}" "${escapedQuery}"`;
         Logger.log(`[runQuery] Executing: ${command}`);
 
         // 50 MB buffer – large ledgers can produce significant CSV output

--- a/styles.css
+++ b/styles.css
@@ -54,6 +54,35 @@
 	opacity: 1;
 }
 
+.bql-format-select {
+	padding: 2px 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	color: var(--text-muted);
+	border-radius: 3px;
+	cursor: pointer;
+	font-size: 11px;
+	opacity: 0.7;
+	transition: opacity 0.2s ease;
+}
+
+.bql-format-select:hover,
+.bql-format-select:focus {
+	opacity: 1;
+	outline: none;
+}
+
+.bql-text-result {
+	font-family: var(--font-monospace);
+	font-size: 0.85em;
+	white-space: pre;
+	overflow-x: auto;
+	padding: 8px 0;
+	color: var(--text-normal);
+	background: none;
+	border: none;
+}
+
 .bql-query-details {
 	margin: 0 0 12px 0;
 	border-bottom: none;


### PR DESCRIPTION
**[Refactor] Add output format selector to BQL code blocks (#111)**

---

**Summary**

Adds support for multiple output formats in `bql` code block queries, replacing the hardcoded CSV-only output. Users can now switch between formats directly from the query toolbar without editing the code block.

**Changes**

- **queryRunner.ts** — Introduced `BQLFormat` type (`'csv' | 'text' | 'beancount'`) and added an optional `format` parameter to `runQuery()` (defaults to `'csv'`). Passes the format to `bean-query` via its `-f` flag. Fully backward-compatible — all existing controller calls are unaffected.

- **index.ts** — Re-exports `BQLFormat` for use across the plugin.

- **main.ts** — Updated `plugin.runQuery()` to accept the optional `format` parameter, forwarding it to the underlying `runQuery` util.

- **BQLCodeBlockProcessor.ts** — Added a `<select>` dropdown in the BQL toolbar alongside the existing Refresh / Copy / Export buttons. Options: **Table** (csv), **Text** (text), **Beancount** (beancount). Changing the format re-runs the query immediately. CSV renders as an HTML table (existing behaviour); text and beancount formats render in a monospace `<pre>` block. Export file extension updates to match the selected format (`.csv` or `.txt`).

- **styles.css** — Added `.bql-format-select` styles (matching existing button aesthetic) and `.bql-text-result` styles for preformatted output.

**Testing**

- CSV (Table) format — renders table as before
- Text format — renders `bean-query` text output in a `<pre>` block
- Beancount format — renders beancount-syntax output in a `<pre>` block
- Export button saves with correct extension per format
- All existing controllers (`OverviewController`, `BalanceSheetController`, etc.) unaffected — they still call `runQuery` without a format argument