### PR TITLE
Added support for financial indicators

### DIFF
--- a/docs-site/docs/core-features/unified-dashboard/overview.md
+++ b/docs-site/docs/core-features/unified-dashboard/overview.md
@@ -24,6 +24,68 @@ At-a-glance metrics displayed at the top:
 
 ---
 
+## 🎯 Financial Indicators
+
+Below the KPI cards, the **Financial Indicators** section lets you define and track Budgets and Savings Targets backed by live BQL data.
+
+### Budgets
+
+A Budget tracks spending against a periodic limit for an expense account.
+
+Each budget card shows:
+- **Name** and expense account
+- **Progress bar** — colored green (on track), orange (≥75%), or red (over budget)
+- **`$spent of $available`** label with percentage
+- **Status pill** — `On Track`, `Warning`, or `Over Budget`
+- **Stats row**: Base Target · Rollover amount (if enabled) · Available (= Base + Rollover)
+
+**Rollover budgets** accumulate unspent amounts across cycles. For example, if you budget $120/month and only spend $110, the extra $10 rolls forward and the next month's available budget becomes $130.
+
+#### Adding a Budget
+
+Click **+ Add Budget** and fill in:
+
+| Field | Description |
+|---|---|
+| Name | Display label (e.g. `Groceries`) |
+| Expense Account | The `Expenses:*` account to track (autocomplete) |
+| Period | `Monthly` or `Weekly` |
+| Target Amount | Spending limit per cycle |
+| Currency | Tracking currency (defaults to Operating Currency) |
+| Enable Rollover | Roll unspent budget into next cycle |
+| Start Date | When the budget begins (only shown when rollover is off) |
+
+This writes an `event "Indicator" "Budget"` directive to `events.beancount`:
+
+```beancount
+2026-01-01 event "Indicator" "Budget"
+  name: "Groceries"
+  accountQuery: "Expenses:Food:Groceries"
+  cycle: "Monthly"
+  target: 500.00
+  currency: "USD"
+  isRollover: 1
+```
+
+### Targets
+
+A Target tracks progress toward a savings or accumulation goal for an asset account.
+
+Each target card shows:
+- **Name** and asset account
+- **Progress bar** colored by completion percentage
+- **Stats row**: Goal · Saved so far · Still needed
+
+#### Adding a Target
+
+Click **+ Add Target** and fill in the same fields as a budget, but select an `Assets:*` account. This writes an `event "Indicator" "Target"` directive to `events.beancount`.
+
+### Refresh
+
+Click the **↺ refresh button** (top-right of the section) to re-run all indicator queries without reloading the full dashboard.
+
+---
+
 ## 🔍 Behind the Scenes: BQL Queries
 
 All data on this tab comes from direct **bean-query** BQL queries. Here are the exact queries used:
@@ -70,6 +132,32 @@ WHERE account ~ '^(Assets|Liabilities)' ORDER BY year, month
 ```
 
 Groups data by month and gets the last cumulative balance for each period, converted to your operating currency.
+
+### Financial Indicators
+
+**Budget / Target list** (reads all `Indicator` events from `events.beancount`):
+```sql
+SELECT date AS _startDate, meta('name') AS _name, meta('accountQuery') AS _accountString,
+       meta('cycle') AS _period, bool(meta('isRollover')) AS _isRollOver,
+       meta('target') AS _budgetAmount, meta('currency') AS _currency
+FROM events WHERE type='Indicator' AND description='Budget'
+```
+
+**Status query — rollover monthly budget** (one query per indicator):
+```sql
+SELECT year, month,
+  number(only('USD', convert(sum(position), 'USD'))) AS _expenseThisCycle,
+  ((year(today())-year(2026-01-01))*12+(month(today())-month(2026-01-01))+1)*500
+    - last(number(only('USD', convert(balance, 'USD')))) AS _remainingThisCycle
+FROM account ~ '^Expenses:Food:Groceries' OPEN ON 2026-01-01
+ORDER BY year DESC, month DESC LIMIT 1
+```
+
+The `_remainingThisCycle` formula multiplies cycles elapsed × base target, then subtracts the current running balance, giving the true rollover-adjusted remaining amount.
+
+:::note bean-query CSV behavior
+`bean-query -f csv` lowercases all column alias characters. `_startDate` becomes `_startdate` in the CSV output. The plugin's `col()` helper handles this automatically.
+:::
 
 :::tip
 You can run these queries yourself in a BQL code block or use them as templates for custom financial dashboards!

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -125,6 +125,30 @@ export function getHistoricalNetProfitDataQuery(interval: 'month' | 'week' = 'mo
 	}
 	return `SELECT year, month, only('${currency}', convert(sum(position), '${currency}', last(date_add(date(year + int(month/12), (month%12+1), 1), -1)))) AS _worth WHERE account ~ '^(Income|Expenses)' GROUP BY year, month ORDER BY year, month`;
 }
+// --- List Budget/Target Quries ---	
+export function getBudgetListQuery(): string {
+	return `SELECT date AS _startDate, meta('name') AS _name, meta('accountQuery') AS _accountString, meta('cycle') AS _period, bool(meta('isRollover')) AS _isRollOver, meta('target') AS _budgetAmount, meta('currency') AS _currency FROM events WHERE type='Indicator' AND description='Budget'`;
+}
+
+export function getTargetListQuery(): string {
+	return `SELECT date AS _startDate, meta('name') AS _name, meta('accountQuery') AS _accountString, meta('cycle') AS _period, bool(meta('isRollover')) AS _isRollOver, meta('target') AS _targetAmount, meta('currency') AS _currency FROM events WHERE type='Indicator' AND description='Target'`;
+}
+
+
+// --- Budget/Target Queries ---
+
+export function getIndicatorStatusQuery(isRollOver: boolean, currency: string, accountString: string, budgetAmount: number, startDate: string, period: string): string {
+	if (isRollOver) {
+		if (period === 'week') {
+			return `SELECT year, date_part('week', date), number(only('${currency}', convert(sum(position), '${currency}'))) AS _expenseThisCycle, ((year(today())-year(${startDate}))*52+(date_part('week', today())-date_part('week',${startDate}))+1)*${budgetAmount}-last(number(only('${currency}',convert(balance, '${currency}')))) AS _remainingThisCycle FROM account ~ '^${accountString}' OPEN ON ${startDate} ORDER BY year DESC, date_part('week', date) DESC LIMIT 1`;
+		}
+		return `SELECT year, month, number(only('${currency}', convert(sum(position), '${currency}'))) AS _expenseThisCycle, ((year(today())-year(${startDate}))*12+(month(today())-month(${startDate}))+1)*${budgetAmount}-last(number(only('${currency}',convert(balance, '${currency}')))) AS _remainingThisCycle FROM account ~ '^${accountString}' OPEN ON ${startDate} ORDER BY year DESC, month DESC LIMIT 1`;
+	} else {
+		return `SELECT date, number(only('${currency}', convert(sum(position), '${currency}'))) AS _expenseThisCycle, ${budgetAmount}-number(only('${currency}', convert(sum(position), '${currency}'))) AS _remainingThisCycle WHERE account ~ '^${accountString}' AND date_trunc('${period}', date)=date_trunc('${period}', today())`;
+	}
+}
+
+
 
 // --- Commodities Queries ---
 
@@ -153,4 +177,8 @@ export function getStaleCommoditiesQuery(daysOld: number, currency: string): str
 
 export function getAllPricesQuery(limit: number = 100): string {
 	return `SELECT date, currency, position FROM #prices ORDER BY date DESC LIMIT ${limit}`;
+}
+
+export function getAllCurrenciesQuery(): string {
+	return `SELECT distinct(currency) AS currency_`;
 }

--- a/src/ui/modals/AddBudgetModal.svelte
+++ b/src/ui/modals/AddBudgetModal.svelte
@@ -1,0 +1,307 @@
+<!-- src/ui/modals/AddBudgetModal.svelte -->
+<script lang="ts">
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	// Props
+	export let accounts: string[] = [];
+	export let currencies: string[] = ['INR', 'USD', 'EUR', 'GBP'];
+	export let defaultCurrency: string = 'USD';
+
+	// Form state
+	let name: string = '';
+	let accountQuery: string = '';
+	let cycle: 'Monthly' | 'Weekly' = 'Monthly';
+	let target: string = '';
+	let currency: string = defaultCurrency;
+	let isRollover: boolean = false;
+	let startDate: string = new Date().toISOString().split('T')[0];
+
+	// UI state
+	let nameError: string = '';
+	let accountError: string = '';
+	let targetError: string = '';
+
+	// Filtered expense accounts
+	$: expenseAccounts = accounts.filter(a => a.startsWith('Expenses'));
+	$: filteredAccounts = accountQuery
+		? expenseAccounts.filter(a => a.toLowerCase().includes(accountQuery.toLowerCase()))
+		: expenseAccounts;
+	let showDropdown = false;
+
+	onMount(() => {
+		currency = defaultCurrency;
+	});
+
+	function validate(): boolean {
+		let valid = true;
+		nameError = '';
+		accountError = '';
+		targetError = '';
+
+		if (!name.trim()) {
+			nameError = 'Name is required';
+			valid = false;
+		}
+		if (!accountQuery.trim()) {
+			accountError = 'Account is required';
+			valid = false;
+		}
+		const t = parseFloat(target);
+		if (!target || isNaN(t) || t <= 0) {
+			targetError = 'Enter a positive number';
+			valid = false;
+		}
+		return valid;
+	}
+
+	function selectAccount(acc: string) {
+		accountQuery = acc;
+		showDropdown = false;
+	}
+
+	function handleSave() {
+		if (!validate()) return;
+		dispatch('save', {
+			name: name.trim(),
+			accountQuery: accountQuery.trim(),
+			cycle,
+			target: parseFloat(target),
+			currency,
+			isRollover,
+			startDate,
+		});
+	}
+
+	function handleCancel() {
+		dispatch('cancel');
+	}
+</script>
+
+<div class="indicator-modal">
+	<h2>Add Budget</h2>
+
+	<div class="form-group">
+		<label for="budget-name">Name <span class="required">*</span></label>
+		<input
+			id="budget-name"
+			type="text"
+			bind:value={name}
+			placeholder="e.g. Total Monthly Expenses"
+			class:error={nameError}
+		/>
+		{#if nameError}<span class="error-msg">{nameError}</span>{/if}
+	</div>
+
+	<div class="form-group">
+		<label for="budget-account">Expense Account <span class="required">*</span></label>
+		<div class="autocomplete-wrapper">
+			<input
+				id="budget-account"
+				type="text"
+				bind:value={accountQuery}
+				placeholder="e.g. Expenses:Food"
+				class:error={accountError}
+				on:focus={() => (showDropdown = true)}
+				on:blur={() => setTimeout(() => (showDropdown = false), 150)}
+			/>
+			{#if showDropdown && filteredAccounts.length > 0}
+				<ul class="autocomplete-dropdown">
+					{#each filteredAccounts.slice(0, 8) as acc}
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+						<li on:click={() => selectAccount(acc)}>{acc}</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+		{#if accountError}<span class="error-msg">{accountError}</span>{/if}
+	</div>
+
+	<div class="form-row">
+		<div class="form-group">
+			<label for="budget-cycle">Period</label>
+			<select id="budget-cycle" bind:value={cycle}>
+				<option value="Monthly">Monthly</option>
+				<option value="Weekly">Weekly</option>
+			</select>
+		</div>
+
+		<div class="form-group">
+			<label for="budget-target">Target <span class="required">*</span></label>
+			<input
+				id="budget-target"
+				type="number"
+				min="0"
+				step="0.01"
+				bind:value={target}
+				placeholder="0.00"
+				class:error={targetError}
+			/>
+			{#if targetError}<span class="error-msg">{targetError}</span>{/if}
+		</div>
+
+		<div class="form-group">
+			<label for="budget-currency">Currency</label>
+			<select id="budget-currency" bind:value={currency}>
+				{#each currencies as c}
+					<option value={c}>{c}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+
+	<div class="form-group rollover-row">
+		<label class="toggle-label">
+			<input type="checkbox" bind:checked={isRollover} />
+			Roll over
+		</label>
+	</div>
+
+	{#if isRollover}
+		<div class="form-group">
+			<label for="budget-start">Start Date</label>
+			<input id="budget-start" type="date" bind:value={startDate} />
+		</div>
+	{/if}
+
+	<div class="modal-actions">
+		<button class="cancel-btn" on:click={handleCancel}>Cancel</button>
+		<button class="save-btn" on:click={handleSave}>Save Budget</button>
+	</div>
+</div>
+
+<style>
+	.indicator-modal {
+		padding: var(--size-4-4);
+	}
+
+	.indicator-modal h2 {
+		margin: 0 0 var(--size-4-4);
+		font-size: var(--font-ui-larger);
+		color: var(--text-normal);
+	}
+
+	.form-group {
+		margin-bottom: var(--size-4-3);
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.form-row {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr;
+		gap: var(--size-4-3);
+	}
+
+	label {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+
+	.required {
+		color: var(--text-error);
+	}
+
+	input[type='text'],
+	input[type='number'],
+	input[type='date'],
+	select {
+		padding: var(--size-4-1) var(--size-4-2);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		background: var(--background-primary);
+		color: var(--text-normal);
+		font-size: var(--font-ui-small);
+		width: 100%;
+	}
+
+	input.error,
+	select.error {
+		border-color: var(--text-error);
+	}
+
+	.error-msg {
+		color: var(--text-error);
+		font-size: var(--font-ui-smaller);
+	}
+
+	.autocomplete-wrapper {
+		position: relative;
+	}
+
+	.autocomplete-dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		max-height: 160px;
+		overflow-y: auto;
+		list-style: none;
+		margin: 2px 0 0;
+		padding: 0;
+	}
+
+	.autocomplete-dropdown li {
+		padding: var(--size-4-1) var(--size-4-2);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+
+	.autocomplete-dropdown li:hover {
+		background: var(--background-modifier-hover);
+	}
+
+	.rollover-row {
+		flex-direction: row;
+		align-items: center;
+	}
+
+	.toggle-label {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		cursor: pointer;
+		color: var(--text-normal);
+		font-size: var(--font-ui-small);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--size-4-2);
+		margin-top: var(--size-4-4);
+		padding-top: var(--size-4-3);
+		border-top: 1px solid var(--background-modifier-border);
+	}
+
+	.cancel-btn {
+		padding: var(--size-4-1) var(--size-4-4);
+		background: var(--interactive-normal);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		color: var(--text-normal);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+
+	.save-btn {
+		padding: var(--size-4-1) var(--size-4-4);
+		background: var(--interactive-accent);
+		border: none;
+		border-radius: var(--radius-s);
+		color: var(--text-on-accent);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+
+	.save-btn:hover {
+		background: var(--interactive-accent-hover);
+	}
+</style>

--- a/src/ui/modals/AddBudgetModal.ts
+++ b/src/ui/modals/AddBudgetModal.ts
@@ -1,0 +1,97 @@
+// src/ui/modals/AddBudgetModal.ts
+
+import { App, Modal, Notice } from 'obsidian';
+import type BeancountPlugin from '../../main';
+import AddBudgetModalComponent from './AddBudgetModal.svelte';
+import { getOpenAccounts, runQuery, createIndicatorDirective } from '../../utils';
+import { getAllCurrenciesQuery } from '../../queries';
+import { parse as parseCsv } from 'csv-parse/sync';
+import { Logger } from '../../utils/logger';
+
+export class AddBudgetModal extends Modal {
+    plugin: BeancountPlugin;
+    private component: any;
+    private onSuccess?: () => void;
+
+    constructor(app: App, plugin: BeancountPlugin, onSuccess?: () => void) {
+        super(app);
+        this.plugin = plugin;
+        this.onSuccess = onSuccess;
+    }
+
+    async onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.style.maxWidth = '560px';
+        this.modalEl.style.width = '90vw';
+        this.setTitle('Add Budget');
+
+        const operatingCurrency = this.plugin.settings.operatingCurrency || 'USD';
+        // Fetch accounts and currencies from the ledger, fall back silently on error
+        let accounts: string[] = [];
+        let currencies: string[] = [operatingCurrency];
+        try {
+            const [accs, csvResult] = await Promise.all([
+                getOpenAccounts(this.plugin),
+                runQuery(this.plugin, getAllCurrenciesQuery()).catch(() => ''),
+            ]);
+            accounts = accs;
+            if (csvResult) {
+                const rows = parseCsv(csvResult, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+                const fetched = rows.map((r: any) => r['currency_']).filter(Boolean) as string[];
+                if (fetched.length > 0) currencies = fetched;
+            }
+            // Always include the operating currency
+            if (!currencies.includes(operatingCurrency)) currencies.unshift(operatingCurrency);
+        } catch (err) {
+            Logger.log('[AddBudgetModal] Could not prefetch accounts/currencies:', err);
+        }
+
+        this.component = new (AddBudgetModalComponent as any)({
+            target: contentEl,
+            props: {
+                accounts,
+                currencies,
+                defaultCurrency: operatingCurrency,
+            },
+        });
+
+        this.component.$on('save', async (e: any) => {
+            const { name, accountQuery, cycle, target, currency, isRollover, startDate } = e.detail;
+            Logger.log('[AddBudgetModal] save event', e.detail);
+
+            try {
+                const result = await createIndicatorDirective(this.plugin, {
+                    type: 'Budget',
+                    name,
+                    accountQuery,
+                    cycle,
+                    target,
+                    currency,
+                    isRollover,
+                    startDate,
+                });
+
+                if (result.success) {
+                    new Notice(`Budget "${name}" created successfully`);
+                    this.close();
+                    if (this.onSuccess) this.onSuccess();
+                } else {
+                    new Notice(`Failed to create budget: ${result.error || 'Unknown error'}`);
+                }
+            } catch (error) {
+                Logger.error('[AddBudgetModal] Error creating budget:', error);
+                new Notice(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            }
+        });
+
+        this.component.$on('cancel', () => this.close());
+    }
+
+    onClose() {
+        if (this.component) {
+            this.component.$destroy();
+            this.component = null;
+        }
+    }
+}

--- a/src/ui/modals/AddTargetModal.svelte
+++ b/src/ui/modals/AddTargetModal.svelte
@@ -1,0 +1,307 @@
+<!-- src/ui/modals/AddTargetModal.svelte -->
+<script lang="ts">
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	// Props
+	export let accounts: string[] = [];
+	export let currencies: string[] = ['INR', 'USD', 'EUR', 'GBP'];
+	export let defaultCurrency: string = 'USD';
+
+	// Form state
+	let name: string = '';
+	let accountQuery: string = '';
+	let cycle: 'Monthly' | 'Weekly' = 'Monthly';
+	let target: string = '';
+	let currency: string = defaultCurrency;
+	let isRollover: boolean = false;
+	let startDate: string = new Date().toISOString().split('T')[0];
+
+	// UI state
+	let nameError: string = '';
+	let accountError: string = '';
+	let targetError: string = '';
+
+	// Filtered asset accounts
+	$: assetAccounts = accounts.filter(a => a.startsWith('Assets'));
+	$: filteredAccounts = accountQuery
+		? assetAccounts.filter(a => a.toLowerCase().includes(accountQuery.toLowerCase()))
+		: assetAccounts;
+	let showDropdown = false;
+
+	onMount(() => {
+		currency = defaultCurrency;
+	});
+
+	function validate(): boolean {
+		let valid = true;
+		nameError = '';
+		accountError = '';
+		targetError = '';
+
+		if (!name.trim()) {
+			nameError = 'Name is required';
+			valid = false;
+		}
+		if (!accountQuery.trim()) {
+			accountError = 'Account is required';
+			valid = false;
+		}
+		const t = parseFloat(target);
+		if (!target || isNaN(t) || t <= 0) {
+			targetError = 'Enter a positive number';
+			valid = false;
+		}
+		return valid;
+	}
+
+	function selectAccount(acc: string) {
+		accountQuery = acc;
+		showDropdown = false;
+	}
+
+	function handleSave() {
+		if (!validate()) return;
+		dispatch('save', {
+			name: name.trim(),
+			accountQuery: accountQuery.trim(),
+			cycle,
+			target: parseFloat(target),
+			currency,
+			isRollover,
+			startDate,
+		});
+	}
+
+	function handleCancel() {
+		dispatch('cancel');
+	}
+</script>
+
+<div class="indicator-modal">
+	<h2>Add Target</h2>
+
+	<div class="form-group">
+		<label for="target-name">Name <span class="required">*</span></label>
+		<input
+			id="target-name"
+			type="text"
+			bind:value={name}
+			placeholder="e.g. Emergency Fund"
+			class:error={nameError}
+		/>
+		{#if nameError}<span class="error-msg">{nameError}</span>{/if}
+	</div>
+
+	<div class="form-group">
+		<label for="target-account">Asset Account <span class="required">*</span></label>
+		<div class="autocomplete-wrapper">
+			<input
+				id="target-account"
+				type="text"
+				bind:value={accountQuery}
+				placeholder="e.g. Assets:Savings"
+				class:error={accountError}
+				on:focus={() => (showDropdown = true)}
+				on:blur={() => setTimeout(() => (showDropdown = false), 150)}
+			/>
+			{#if showDropdown && filteredAccounts.length > 0}
+				<ul class="autocomplete-dropdown">
+					{#each filteredAccounts.slice(0, 8) as acc}
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+						<li on:click={() => selectAccount(acc)}>{acc}</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+		{#if accountError}<span class="error-msg">{accountError}</span>{/if}
+	</div>
+
+	<div class="form-row">
+		<div class="form-group">
+			<label for="target-cycle">Period</label>
+			<select id="target-cycle" bind:value={cycle}>
+				<option value="Monthly">Monthly</option>
+				<option value="Weekly">Weekly</option>
+			</select>
+		</div>
+
+		<div class="form-group">
+			<label for="target-amount">Target Amount <span class="required">*</span></label>
+			<input
+				id="target-amount"
+				type="number"
+				min="0"
+				step="0.01"
+				bind:value={target}
+				placeholder="0.00"
+				class:error={targetError}
+			/>
+			{#if targetError}<span class="error-msg">{targetError}</span>{/if}
+		</div>
+
+		<div class="form-group">
+			<label for="target-currency">Currency</label>
+			<select id="target-currency" bind:value={currency}>
+				{#each currencies as c}
+					<option value={c}>{c}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+
+	<div class="form-group rollover-row">
+		<label class="toggle-label">
+			<input type="checkbox" bind:checked={isRollover} />
+			Roll over
+		</label>
+	</div>
+
+	{#if isRollover}
+		<div class="form-group">
+			<label for="target-start">Start Date</label>
+			<input id="target-start" type="date" bind:value={startDate} />
+		</div>
+	{/if}
+
+	<div class="modal-actions">
+		<button class="cancel-btn" on:click={handleCancel}>Cancel</button>
+		<button class="save-btn" on:click={handleSave}>Save Target</button>
+	</div>
+</div>
+
+<style>
+	.indicator-modal {
+		padding: var(--size-4-4);
+	}
+
+	.indicator-modal h2 {
+		margin: 0 0 var(--size-4-4);
+		font-size: var(--font-ui-larger);
+		color: var(--text-normal);
+	}
+
+	.form-group {
+		margin-bottom: var(--size-4-3);
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.form-row {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr;
+		gap: var(--size-4-3);
+	}
+
+	label {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+
+	.required {
+		color: var(--text-error);
+	}
+
+	input[type='text'],
+	input[type='number'],
+	input[type='date'],
+	select {
+		padding: var(--size-4-1) var(--size-4-2);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		background: var(--background-primary);
+		color: var(--text-normal);
+		font-size: var(--font-ui-small);
+		width: 100%;
+	}
+
+	input.error,
+	select.error {
+		border-color: var(--text-error);
+	}
+
+	.error-msg {
+		color: var(--text-error);
+		font-size: var(--font-ui-smaller);
+	}
+
+	.autocomplete-wrapper {
+		position: relative;
+	}
+
+	.autocomplete-dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		max-height: 160px;
+		overflow-y: auto;
+		list-style: none;
+		margin: 2px 0 0;
+		padding: 0;
+	}
+
+	.autocomplete-dropdown li {
+		padding: var(--size-4-1) var(--size-4-2);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+
+	.autocomplete-dropdown li:hover {
+		background: var(--background-modifier-hover);
+	}
+
+	.rollover-row {
+		flex-direction: row;
+		align-items: center;
+	}
+
+	.toggle-label {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		cursor: pointer;
+		color: var(--text-normal);
+		font-size: var(--font-ui-small);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--size-4-2);
+		margin-top: var(--size-4-4);
+		padding-top: var(--size-4-3);
+		border-top: 1px solid var(--background-modifier-border);
+	}
+
+	.cancel-btn {
+		padding: var(--size-4-1) var(--size-4-4);
+		background: var(--interactive-normal);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		color: var(--text-normal);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+
+	.save-btn {
+		padding: var(--size-4-1) var(--size-4-4);
+		background: var(--interactive-accent);
+		border: none;
+		border-radius: var(--radius-s);
+		color: var(--text-on-accent);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+
+	.save-btn:hover {
+		background: var(--interactive-accent-hover);
+	}
+</style>

--- a/src/ui/modals/AddTargetModal.ts
+++ b/src/ui/modals/AddTargetModal.ts
@@ -1,0 +1,97 @@
+// src/ui/modals/AddTargetModal.ts
+
+import { App, Modal, Notice } from 'obsidian';
+import type BeancountPlugin from '../../main';
+import AddTargetModalComponent from './AddTargetModal.svelte';
+import { getOpenAccounts, runQuery, createIndicatorDirective } from '../../utils';
+import { getAllCurrenciesQuery } from '../../queries';
+import { parse as parseCsv } from 'csv-parse/sync';
+import { Logger } from '../../utils/logger';
+
+export class AddTargetModal extends Modal {
+    plugin: BeancountPlugin;
+    private component: any;
+    private onSuccess?: () => void;
+
+    constructor(app: App, plugin: BeancountPlugin, onSuccess?: () => void) {
+        super(app);
+        this.plugin = plugin;
+        this.onSuccess = onSuccess;
+    }
+
+    async onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.style.maxWidth = '560px';
+        this.modalEl.style.width = '90vw';
+        this.setTitle('Add Target');
+
+        const operatingCurrency = this.plugin.settings.operatingCurrency || 'USD';
+        // Fetch accounts and currencies from the ledger, fall back silently on error
+        let accounts: string[] = [];
+        let currencies: string[] = [operatingCurrency];
+        try {
+            const [accs, csvResult] = await Promise.all([
+                getOpenAccounts(this.plugin),
+                runQuery(this.plugin, getAllCurrenciesQuery()).catch(() => ''),
+            ]);
+            accounts = accs;
+            if (csvResult) {
+                const rows = parseCsv(csvResult, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+                const fetched = rows.map((r: any) => r['currency_']).filter(Boolean) as string[];
+                if (fetched.length > 0) currencies = fetched;
+            }
+            // Always include the operating currency
+            if (!currencies.includes(operatingCurrency)) currencies.unshift(operatingCurrency);
+        } catch (err) {
+            Logger.log('[AddTargetModal] Could not prefetch accounts/currencies:', err);
+        }
+
+        this.component = new (AddTargetModalComponent as any)({
+            target: contentEl,
+            props: {
+                accounts,
+                currencies,
+                defaultCurrency: operatingCurrency,
+            },
+        });
+
+        this.component.$on('save', async (e: any) => {
+            const { name, accountQuery, cycle, target, currency, isRollover, startDate } = e.detail;
+            Logger.log('[AddTargetModal] save event', e.detail);
+
+            try {
+                const result = await createIndicatorDirective(this.plugin, {
+                    type: 'Target',
+                    name,
+                    accountQuery,
+                    cycle,
+                    target,
+                    currency,
+                    isRollover,
+                    startDate,
+                });
+
+                if (result.success) {
+                    new Notice(`Target "${name}" created successfully`);
+                    this.close();
+                    if (this.onSuccess) this.onSuccess();
+                } else {
+                    new Notice(`Failed to create target: ${result.error || 'Unknown error'}`);
+                }
+            } catch (error) {
+                Logger.error('[AddTargetModal] Error creating target:', error);
+                new Notice(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            }
+        });
+
+        this.component.$on('cancel', () => this.close());
+    }
+
+    onClose() {
+        if (this.component) {
+            this.component.$destroy();
+            this.component = null;
+        }
+    }
+}

--- a/src/ui/partials/dashboard/IndicatorsSection.svelte
+++ b/src/ui/partials/dashboard/IndicatorsSection.svelte
@@ -1,0 +1,734 @@
+<!-- src/ui/partials/dashboard/IndicatorsSection.svelte -->
+<script lang="ts">
+	import { onMount, createEventDispatcher } from 'svelte';
+	import { parse as parseCsv } from 'csv-parse/sync';
+	import { runQuery } from '../../../utils';
+	import { getBudgetListQuery, getTargetListQuery, getIndicatorStatusQuery } from '../../../queries';
+
+	export let plugin: any = null;
+
+	const dispatch = createEventDispatcher();
+
+	interface IndicatorItem {
+		name: string;
+		accountString: string;
+		period: string;
+		isRollOver: boolean;
+		targetAmount: number;
+		currency: string;
+		startDate: string;
+		spent: number;
+		remaining: number;
+		loading: boolean;
+		error: string | null;
+	}
+
+	type IndicatorView = 'Budgets' | 'Targets';
+	let activeView: IndicatorView = 'Budgets';
+	let budgets: IndicatorItem[] = [];
+	let targets: IndicatorItem[] = [];
+	let isLoading = false;
+	let loadError: string | null = null;
+
+	$: currentItems = activeView === 'Budgets' ? budgets : targets;
+
+	function col(row: any, name: string): any {
+		// bean-query preserves leading underscores but LOWERCASES all alias characters.
+		// e.g.  SELECT date AS _startDate  →  CSV header is "_startdate", not "_startDate".
+		// Try lowercase first, then original, then bare (no leading underscore) variants.
+		const lower = name.toLowerCase();
+		if (row[lower] !== undefined) return row[lower];
+		if (row[name] !== undefined) return row[name];
+		const bare = name.startsWith('_') ? name.slice(1) : name;
+		const bareLower = bare.toLowerCase();
+		if (row[bareLower] !== undefined) return row[bareLower];
+		return row[bare];
+	}
+
+	function parseBool(val: any): boolean {
+		if (typeof val === 'boolean') return val;
+		const s = String(val).toLowerCase();
+		return s === 'true' || s === '1';
+	}
+
+	function parseNumericValue(val: any): number {
+		if (val === null || val === undefined || val === '') return 0;
+		if (typeof val === 'number') return val;
+		const match = String(val).match(/[+-]?[\d.]+/);
+		return match ? parseFloat(match[0]) : 0;
+	}
+
+	function formatAmount(amount: number, currency: string): string {
+		const abs = Math.abs(amount);
+		return `${abs.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
+	}
+
+	// For rollover budgets, available budget = spent + remaining (base + accumulated rollover).
+	// For non-rollover, available = base target.
+	function getEffectiveTarget(item: IndicatorItem): number {
+		if (item.isRollOver) return item.spent + item.remaining;
+		return item.targetAmount;
+	}
+
+	function getPct(item: IndicatorItem): number {
+		const eff = getEffectiveTarget(item);
+		if (eff <= 0) return 0;
+		return (item.spent / eff) * 100;
+	}
+
+	function getBarColor(pct: number, isBudget: boolean): string {
+		if (isBudget) {
+			if (pct >= 100) return 'var(--color-red, #e05252)';
+			if (pct >= 75) return 'var(--color-orange, #e8a027)';
+			return 'var(--color-green, #4caf74)';
+		}
+		if (pct >= 100) return 'var(--color-green, #4caf74)';
+		if (pct >= 75) return 'var(--interactive-accent)';
+		return 'var(--interactive-accent)';
+	}
+
+	function getStatusBadge(pct: number, isBudget: boolean): { label: string; cls: string } {
+		if (isBudget) {
+			if (pct >= 100) return { label: 'Over Budget', cls: 'status-over' };
+			if (pct >= 75)  return { label: 'Warning',     cls: 'status-warn' };
+			return { label: 'On Track', cls: 'status-good' };
+		}
+		if (pct >= 100) return { label: 'Complete',   cls: 'status-good' };
+		if (pct >= 75)  return { label: 'On Track',   cls: 'status-good' };
+		return { label: 'In Progress', cls: 'status-neutral' };
+	}
+
+	async function loadAll() {
+		if (!plugin) return;
+		isLoading = true;
+		loadError = null;
+		try {
+			await Promise.all([loadBudgets(), loadTargets()]);
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : String(e);
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function loadBudgets() {
+		const csv = await runQuery(plugin, getBudgetListQuery());
+		const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+		const items: IndicatorItem[] = rows.map((r: any) => ({
+			name: col(r, '_name') || '',
+			accountString: col(r, '_accountString') || '',
+			period: col(r, '_period') || 'Monthly',
+			isRollOver: parseBool(col(r, '_isRollOver')),
+			targetAmount: parseNumericValue(col(r, '_budgetAmount')),
+			currency: col(r, '_currency') || '',
+			startDate: col(r, '_startDate') || '',
+			spent: 0,
+			remaining: 0,
+			loading: true,
+			error: null,
+		}));
+		budgets = items;
+		await Promise.all(items.map((_: any, i: number) => loadBudgetStatus(i)));
+	}
+
+	async function loadBudgetStatus(index: number) {
+		const item = budgets[index];
+		if (!item.accountString || !item.startDate || item.targetAmount <= 0) {
+			budgets = budgets.map((b, i) => i === index
+				? { ...b, loading: false, error: 'Indicator data incomplete — check the event directive in events.beancount.' }
+				: b);
+			return;
+		}
+		try {
+			const period = item.period.toLowerCase() === 'weekly' ? 'week' : 'month';
+			const csv = await runQuery(
+				plugin,
+				getIndicatorStatusQuery(item.isRollOver, item.currency, item.accountString, item.targetAmount, item.startDate, period)
+			);
+			const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+			if (rows.length > 0) {
+				const row = rows[0];
+				const spent = Math.abs(parseNumericValue(col(row, '_expenseThisCycle')));
+				const remaining = item.isRollOver
+					? parseNumericValue(col(row, '_remainingThisCycle'))
+					: item.targetAmount - spent;
+				budgets = budgets.map((b, i) => i === index ? { ...b, spent, remaining, loading: false } : b);
+			} else {
+				budgets = budgets.map((b, i) => i === index ? { ...b, spent: 0, remaining: b.targetAmount, loading: false } : b);
+			}
+		} catch (e) {
+			budgets = budgets.map((b, i) => i === index
+				? { ...b, loading: false, error: e instanceof Error ? e.message : 'Error loading status' } : b);
+		}
+	}
+
+	async function loadTargets() {
+		const csv = await runQuery(plugin, getTargetListQuery());
+		const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+		const items: IndicatorItem[] = rows.map((r: any) => ({
+			name: col(r, '_name') || '',
+			accountString: col(r, '_accountString') || '',
+			period: col(r, '_period') || 'Monthly',
+			isRollOver: parseBool(col(r, '_isRollOver')),
+			targetAmount: parseNumericValue(col(r, '_targetAmount')),
+			currency: col(r, '_currency') || '',
+			startDate: col(r, '_startDate') || '',
+			spent: 0,
+			remaining: 0,
+			loading: true,
+			error: null,
+		}));
+		targets = items;
+		await Promise.all(items.map((_: any, i: number) => loadTargetStatus(i)));
+	}
+
+	async function loadTargetStatus(index: number) {
+		const item = targets[index];
+		if (!item.accountString || !item.startDate || item.targetAmount <= 0) {
+			targets = targets.map((t, i) => i === index
+				? { ...t, loading: false, error: 'Indicator data incomplete — check the event directive in events.beancount.' }
+				: t);
+			return;
+		}
+		try {
+			const period = item.period.toLowerCase() === 'weekly' ? 'week' : 'month';
+			const csv = await runQuery(
+				plugin,
+				getIndicatorStatusQuery(item.isRollOver, item.currency, item.accountString, item.targetAmount, item.startDate, period)
+			);
+			const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+			if (rows.length > 0) {
+				const row = rows[0];
+				const current = parseNumericValue(col(row, '_expenseThisCycle'));
+				targets = targets.map((t, i) => i === index
+					? { ...t, spent: current, remaining: t.targetAmount - current, loading: false } : t);
+			} else {
+				targets = targets.map((t, i) => i === index
+					? { ...t, spent: 0, remaining: t.targetAmount, loading: false } : t);
+			}
+		} catch (e) {
+			targets = targets.map((t, i) => i === index
+				? { ...t, loading: false, error: e instanceof Error ? e.message : 'Error loading status' } : t);
+		}
+	}
+
+	onMount(() => { if (plugin) loadAll(); });
+
+	function setView(view: IndicatorView) { activeView = view; }
+	function handleAddBudget() { dispatch('add-budget'); }
+	function handleAddTarget() { dispatch('add-target'); }
+</script>
+
+<div class="indicators-section">
+	<!-- Header -->
+	<div class="indicators-header">
+		<div class="title-row">
+			<h4>Financial Indicators</h4>
+			<button class="icon-btn" class:spinning={isLoading} on:click={loadAll} title="Refresh" disabled={isLoading}>
+				↺
+			</button>
+		</div>
+		<div class="controls-row">
+			<div class="view-toggle">
+				<button class="toggle-btn" class:active={activeView === 'Budgets'} on:click={() => setView('Budgets')}>
+					Budgets
+					<span class="count-badge" class:active={activeView === 'Budgets'}>{budgets.length}</span>
+				</button>
+				<button class="toggle-btn" class:active={activeView === 'Targets'} on:click={() => setView('Targets')}>
+					Targets
+					<span class="count-badge" class:active={activeView === 'Targets'}>{targets.length}</span>
+				</button>
+			</div>
+			<button class="add-btn" on:click={activeView === 'Budgets' ? handleAddBudget : handleAddTarget}>
+				<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+				{activeView === 'Budgets' ? 'Add Budget' : 'Add Target'}
+			</button>
+		</div>
+	</div>
+
+	<!-- Body -->
+	<div class="indicators-body">
+		{#if isLoading && currentItems.length === 0}
+			<div class="skeleton-grid">
+				<div class="skeleton-card"></div>
+				<div class="skeleton-card"></div>
+			</div>
+		{:else if loadError}
+			<div class="error-banner">
+				<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+				{loadError}
+			</div>
+		{:else if currentItems.length === 0}
+			<div class="empty-state">
+				<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" opacity="0.3">
+					<rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>
+				</svg>
+				<p>No {activeView.toLowerCase()} defined yet.</p>
+				<button class="add-btn" on:click={activeView === 'Budgets' ? handleAddBudget : handleAddTarget}>
+					<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+					Add {activeView === 'Budgets' ? 'Budget' : 'Target'}
+				</button>
+			</div>
+		{:else}
+			<div class="indicators-list">
+				{#each currentItems as item (item.name)}
+					{@const isBudget = activeView === 'Budgets'}
+					{@const effTarget = getEffectiveTarget(item)}
+					{@const pct = getPct(item)}
+					{@const barColor = getBarColor(pct, isBudget)}
+					{@const rolloverAmt = item.isRollOver ? effTarget - item.targetAmount : 0}
+					{@const status = getStatusBadge(pct, isBudget)}
+					<div class="indicator-card" class:over-budget={pct >= 100 && isBudget}>
+
+						<!-- Top row: name / meta left — remaining right -->
+						<div class="card-top">
+							<div class="card-identity">
+								<span class="card-name">{item.name}</span>
+								<div class="card-meta">
+									<span class="meta-chip">
+										<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+										{item.accountString}
+									</span>
+									<span class="meta-chip">
+										<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+										{item.period}
+									</span>
+								</div>
+							</div>
+							{#if !item.loading && !item.error}
+								<div class="card-remaining">
+									<span class="remaining-label">{isBudget ? 'Remaining' : 'Still needed'}</span>
+									<span class="remaining-value" style="color:{barColor};">{formatAmount(Math.max(item.remaining, 0), item.currency)}</span>
+									<span class="status-badge {status.cls}">{status.label}</span>
+								</div>
+							{/if}
+						</div>
+
+						{#if item.loading}
+							<div class="card-loading-area">
+								<div class="mini-skeleton" style="height:10px; width:40%;"></div>
+								<div class="mini-skeleton" style="height:6px;"></div>
+								<div class="mini-skeleton" style="height:10px; width:60%;"></div>
+							</div>
+						{:else if item.error}
+							<div class="card-error">{item.error}</div>
+						{:else}
+							<!-- Progress section -->
+							<div class="progress-section">
+								<div class="progress-label-row">
+									<span class="progress-label-text">{formatAmount(item.spent, item.currency)} of {formatAmount(effTarget, item.currency)}</span>
+									<span class="pct-text" style="color:{barColor};">{(Math.round(pct * 10) / 10).toFixed(1)}%</span>
+								</div>
+								<div class="progress-track">
+									<div class="progress-fill" style="width:{Math.min(pct, 100)}%; background:{barColor};"></div>
+								</div>
+							</div>
+
+							<!-- Bottom stats row -->
+							<div class="stats-row">
+								<div class="stat-block">
+									<span class="stat-label">{isBudget ? 'Base Target' : 'Goal'}</span>
+									<span class="stat-value">{formatAmount(item.targetAmount, item.currency)}</span>
+								</div>
+								{#if item.isRollOver}
+									<div class="stat-block">
+										<span class="stat-label rollover-label">
+											<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
+											Rollover
+										</span>
+										<span class="stat-value rollover-value">{formatAmount(rolloverAmt, item.currency)}</span>
+									</div>
+									<div class="stat-block">
+										<span class="stat-label">Available</span>
+										<span class="stat-value">{formatAmount(effTarget, item.currency)}</span>
+									</div>
+								{:else}
+									<div class="stat-block">
+										<span class="stat-label">{isBudget ? 'Spent' : 'Saved'}</span>
+										<span class="stat-value">{formatAmount(item.spent, item.currency)}</span>
+									</div>
+									<div class="stat-block">
+										<span class="stat-label">{isBudget ? 'Remaining' : 'Still needed'}</span>
+										<span class="stat-value" style="color:{barColor};">{formatAmount(Math.max(item.remaining, 0), item.currency)}</span>
+									</div>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	/* ── Section container ─────────────────────────────── */
+	.indicators-section {
+		margin-top: var(--size-4-6);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		overflow: hidden;
+	}
+
+	/* ── Header ────────────────────────────────────────── */
+	.indicators-header {
+		padding: var(--size-4-3) var(--size-4-4);
+		background: var(--background-secondary);
+		border-bottom: 1px solid var(--background-modifier-border);
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-2);
+	}
+
+	.title-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.title-row h4 {
+		margin: 0;
+		font-size: var(--font-ui-medium);
+		color: var(--text-normal);
+	}
+
+	.controls-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	/* ── Toggle ────────────────────────────────────────── */
+	.view-toggle {
+		display: flex;
+		gap: 2px;
+		background: var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		padding: 2px;
+	}
+
+	.toggle-btn {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 3px 12px;
+		border: none;
+		background: transparent;
+		border-radius: var(--radius-s);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.toggle-btn.active {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+
+	.count-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 17px;
+		height: 15px;
+		padding: 0 4px;
+		border-radius: 8px;
+		font-size: 10px;
+		font-weight: 600;
+		background: var(--background-modifier-border);
+		color: var(--text-muted);
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.count-badge.active {
+		background: rgba(255, 255, 255, 0.22);
+		color: var(--text-on-accent);
+	}
+
+	/* ── Buttons ───────────────────────────────────────── */
+	.add-btn {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 4px 12px;
+		background: var(--interactive-accent);
+		border: none;
+		border-radius: var(--radius-s);
+		color: var(--text-on-accent);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+		transition: background 0.15s;
+	}
+
+	.add-btn:hover { background: var(--interactive-accent-hover); }
+
+	.icon-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 26px;
+		height: 26px;
+		background: transparent;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 15px;
+		line-height: 1;
+		transition: background 0.15s;
+	}
+
+	.icon-btn:hover:not(:disabled) {
+		background: var(--background-modifier-hover);
+		color: var(--text-normal);
+	}
+
+	.icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+	.icon-btn.spinning { animation: spin 0.8s linear infinite; }
+
+	@keyframes spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+
+	/* ── Body ──────────────────────────────────────────── */
+	.indicators-body { padding: var(--size-4-4); }
+
+	/* ── Skeletons ─────────────────────────────────────── */
+	.skeleton-grid {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+	}
+
+	.skeleton-card {
+		height: 96px;
+		border-radius: var(--radius-m);
+		background: var(--background-modifier-border);
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.45; }
+	}
+
+	/* ── Error banner ──────────────────────────────────── */
+	.error-banner {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: var(--size-4-3);
+		background: var(--background-modifier-error-rgb, rgba(255, 0, 0, 0.06));
+		border-radius: var(--radius-s);
+		color: var(--text-error);
+		font-size: var(--font-ui-small);
+	}
+
+	/* ── Empty state ───────────────────────────────────── */
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--size-4-3);
+		padding: var(--size-4-8, 32px) var(--size-4-4);
+		text-align: center;
+	}
+
+	.empty-state p {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+	}
+
+	/* ── Indicators list ───────────────────────────────── */
+	.indicators-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+	}
+
+	/* ── Indicator card (full-width) ───────────────────── */
+	.indicator-card {
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: var(--size-4-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+		transition: box-shadow 0.15s;
+	}
+
+	.indicator-card:hover { box-shadow: 0 2px 12px rgba(0,0,0,0.07); }
+
+	.indicator-card.over-budget {
+		border-left: 3px solid var(--color-red, #e05252);
+	}
+
+	/* ── Top row ───────────────────────────────────────── */
+	.card-top {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: var(--size-4-4);
+	}
+
+	.card-identity {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.card-name {
+		font-size: var(--font-ui-medium);
+		font-weight: 700;
+		color: var(--text-normal);
+		line-height: 1.2;
+	}
+
+	.card-meta {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		flex-wrap: wrap;
+	}
+
+	.meta-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+
+	.meta-chip svg { flex-shrink: 0; opacity: 0.7; }
+
+	/* ── Right: remaining + badge ──────────────────────── */
+	.card-remaining {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 4px;
+		flex-shrink: 0;
+	}
+
+	.remaining-label {
+		font-size: 11px;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.remaining-value {
+		font-size: 20px;
+		font-weight: 700;
+		line-height: 1.1;
+		white-space: nowrap;
+	}
+
+	.status-badge {
+		display: inline-block;
+		padding: 2px 9px;
+		border-radius: 20px;
+		font-size: 11px;
+		font-weight: 500;
+	}
+
+	.status-good    { background: rgba(76,175,116,0.12); color: var(--color-green, #4caf74); }
+	.status-warn    { background: rgba(232,160,39,0.12); color: var(--color-orange, #e8a027); }
+	.status-over    { background: rgba(224,82,82,0.12);  color: var(--color-red, #e05252); }
+	.status-neutral { background: var(--background-modifier-border); color: var(--text-muted); }
+
+	/* ── Progress section ──────────────────────────────── */
+	.progress-section {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+	}
+
+	.progress-label-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.progress-label-text {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+
+	.pct-text {
+		font-size: var(--font-ui-small);
+		font-weight: 600;
+	}
+
+	.progress-track {
+		width: 100%;
+		height: 8px;
+		background: var(--background-modifier-border);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.progress-fill {
+		height: 100%;
+		border-radius: 4px;
+		transition: width 0.4s ease;
+	}
+
+	/* ── Stats row ─────────────────────────────────────── */
+	.stats-row {
+		display: flex;
+		gap: var(--size-4-6);
+		padding-top: var(--size-4-2);
+		border-top: 1px solid var(--background-modifier-border);
+	}
+
+	.stat-block {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.stat-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 3px;
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+
+	.rollover-label { color: var(--color-green, #4caf74); }
+
+	.stat-value {
+		font-size: var(--font-ui-small);
+		font-weight: 600;
+		color: var(--text-normal);
+		white-space: nowrap;
+	}
+
+	.rollover-value { color: var(--color-green, #4caf74); }
+
+	/* ── Card loading/error ────────────────────────────── */
+	.card-loading-area {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+	}
+
+	.mini-skeleton {
+		height: 8px;
+		width: 100%;
+		background: var(--background-modifier-border);
+		border-radius: 4px;
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	.card-error {
+		font-size: var(--font-ui-small);
+		color: var(--text-error);
+	}
+</style>

--- a/src/ui/partials/dashboard/OverviewTab.svelte
+++ b/src/ui/partials/dashboard/OverviewTab.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 	import CardComponent from '../../common/CardComponent.svelte';
+	import IndicatorsSection from './IndicatorsSection.svelte';
 	import type { OverviewController } from '../../../controllers/OverviewController';
 	import { writable, type Writable } from 'svelte/store'; // Import writable
 	import type { OverviewState } from '../../../controllers/OverviewController'; // Import the State type
+	import { AddBudgetModal } from '../../modals/AddBudgetModal';
+	import { AddTargetModal } from '../../modals/AddTargetModal';
 
 	// --- Receive the controller ---
 	export let controller: OverviewController;
+	export let plugin: any = null;
 
 	// --- THIS IS THE FIX ---
 	// 1. Create a local, placeholder store with default values.
@@ -33,6 +37,16 @@
 		if (controller) {
 			controller.loadData();
 		}
+	}
+
+	function handleAddBudget() {
+		if (!plugin) return;
+		new AddBudgetModal(plugin.app, plugin).open();
+	}
+
+	function handleAddTarget() {
+		if (!plugin) return;
+		new AddTargetModal(plugin.app, plugin).open();
 	}
 	// -----------------------
 </script>
@@ -82,6 +96,12 @@
 			<CardComponent label="Monthly Expenses" value={state.monthlyExpenses} comparison="Current month spending" />
 			<CardComponent label="Savings Rate" value={state.savingsRate} comparison="Income minus expenses" />
 		</div>
+
+		<IndicatorsSection
+			{plugin}
+			on:add-budget={handleAddBudget}
+			on:add-target={handleAddTarget}
+		/>
 	{/if}
 </div>
 

--- a/src/ui/views/dashboard/UnifiedDashboardView.svelte
+++ b/src/ui/views/dashboard/UnifiedDashboardView.svelte
@@ -51,7 +51,7 @@
 
     <div class="tab-content">
         {#if activeTab === 'overview'}
-            <OverviewTab controller={overviewController} />
+            <OverviewTab controller={overviewController} {plugin} />
         {:else if activeTab === 'transactions'}
             <TransactionsTab 
                 controller={transactionController}

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -859,6 +859,64 @@ export async function deleteQueryDirective(
     }
 }
 
+// ─── INDICATOR DIRECTIVE (Budget / Target) ─────────────────────────────────────
+
+export interface IndicatorDirectiveParams {
+    type: 'Budget' | 'Target';
+    name: string;
+    accountQuery: string;
+    cycle: 'Monthly' | 'Weekly';
+    target: number;
+    currency: string;
+    isRollover: boolean;
+    startDate: string; // ISO date string YYYY-MM-DD
+}
+
+/**
+ * Writes an event "Indicator" directive to events.beancount.
+ * Format:
+ *   YYYY-MM-DD event "Indicator" "Budget"
+ *     accountQuery: "..."
+ *     name: "..."
+ *     ...
+ */
+export async function createIndicatorDirective(
+    plugin: BeancountPlugin,
+    params: IndicatorDirectiveParams,
+    createBackup: boolean = true
+): Promise<{ success: boolean; error?: string }> {
+    try {
+        const filePath = getTargetFile(plugin, 'event');
+        if (!filePath) return { success: false, error: 'Events file path not set. Please configure the plugin.' };
+
+        const normalizedPath = convertWslPathToWindows(filePath);
+
+        const lines = [
+            `${params.startDate} event "Indicator" "${params.type}"`,
+            `\taccountQuery: "${params.accountQuery}"`,
+            `\tname: "${params.name}"`,
+            `\tcycle: "${params.cycle}"`,
+            `\tisRollover: ${params.isRollover ? 1 : 0}`,
+            `\ttarget: ${params.target.toFixed(2)}`,
+            `\tcurrency: "${params.currency}"`,
+        ];
+        const directiveText = lines.join('\n');
+
+        await createBackupFile(normalizedPath, createBackup, 'createIndicatorDirective');
+        const content = await readFile(normalizedPath, 'utf-8');
+        const newContent = content.endsWith('\n')
+            ? `${content}${directiveText}\n`
+            : `${content}\n${directiveText}\n`;
+        await atomicFileWrite(normalizedPath, newContent);
+
+        Logger.log(`[createIndicatorDirective] Saved ${params.type} indicator "${params.name}"`);
+        return { success: true };
+    } catch (error) {
+        Logger.error('[createIndicatorDirective] Error:', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+}
+
 /**
  * Read all query directives from queries.beancount.
  * Returns a map of name → sql.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,6 +51,8 @@ export {
 	deleteQueryDirective,
 	getQueryDirectives,
 	parseQueryDirectives,
+	createIndicatorDirective,
+	type IndicatorDirectiveParams,
 } from './directives';
 
 // Re-export structuredLayout helpers that some callers pull from utils/index


### PR DESCRIPTION
## Feature: Financial Indicators in Overview Tab (#116)

Adds a **Financial Indicators** section to the Overview tab, allowing users to define, track, and visualise Budgets and Savings Targets backed by live BQL data from their Beancount ledger.

---

### What's New

#### 🎯 Indicators Section (IndicatorsSection.svelte)
- Full-width card layout below the KPI cards in the Overview tab
- **Budgets / Targets toggle** with live count badges
- Per-card display:
  - Bold name + account and period meta chips
  - Full-width progress bar coloured green / orange / red based on spend %
  - `$spent of $available` label with exact percentage
  - Status pill: `On Track`, `Warning`, `Over Budget`, `In Progress`, `Complete`
  - Stats row: **Base Target · Rollover · Available** (rollover budgets) or **Goal · Saved · Still needed** (targets)
- Loading skeletons, per-card error states, and empty state with inline Add button
- Refresh button (↺) re-runs all queries without reloading the dashboard

#### 💰 Rollover Budgets
Unspent budget accumulates across cycles. The status query computes `(cycles elapsed × base target) − running balance` to give a live rollover-adjusted remaining amount.

#### ➕ Add Budget / Add Target Modals
- Form fields: Name, Account (autocomplete filtered to `Expenses:*` / `Assets:*`), Period (Monthly/Weekly), Target Amount, Currency, Rollover toggle, Start Date
- Currency list populated live from `getAllCurrenciesQuery()`, pre-filled with Operating Currency
- On save, writes an `event "Indicator"` directive to `events.beancount`:

```beancount
2026-01-01 event "Indicator" "Budget"
  name: "Groceries"
  accountQuery: "Expenses:Food:Groceries"
  cycle: "Monthly"
  target: 500.00
  currency: "USD"
  isRollover: 1
```

#### 🔧 New BQL Queries (`queries/index.ts`)
- `getBudgetListQuery()` — reads all `Indicator / Budget` events with metadata
- `getTargetListQuery()` — reads all `Indicator / Target` events with metadata
- `getIndicatorStatusQuery(isRollOver, currency, account, target, startDate, period)` — 3 branches: rollover+weekly, rollover+monthly, non-rollover
- `getAllCurrenciesQuery()` — used to populate the currency selector in modals

#### 🐛 bean-query CSV Compatibility Fix
Discovered that `bean-query -f csv` **lowercases all column alias characters** (e.g. `_startDate` → `_startdate`). Added a `col(row, name)` helper that tries the lowercase variant first, falling back to the original name. Also fixed `parseBool()` to handle `'TRUE'` (uppercase) returned by `bool()`.

---

### Files Changed

| File | Change |
|---|---|
| directives.ts | Added `createIndicatorDirective` + `IndicatorDirectiveParams` |
| index.ts | Re-exported new directive function and type |
| index.ts | Added 4 new query functions |
| IndicatorsSection.svelte | New component |
| AddBudgetModal.svelte + `.ts` | New modal |
| AddTargetModal.svelte + `.ts` | New modal |
| OverviewTab.svelte | Added `plugin` prop + `IndicatorsSection` |
| UnifiedDashboardView.svelte | Pass `{plugin}` to `OverviewTab` |
| overview.md | Full Indicators section added |