### PR TITLE
fix(ui): scope .empty-state CSS to avoid collision with Obsidian core

### DIFF
--- a/src/ui/partials/dashboard/CommoditiesTab.svelte
+++ b/src/ui/partials/dashboard/CommoditiesTab.svelte
@@ -373,6 +373,13 @@
 	}
 
 	.empty-state {
+		/* Override Obsidian core's global `.empty-state` rule
+		 * (position:absolute; width:100%; height:100%; top:0) which would
+		 * otherwise turn this placeholder into a full-viewport overlay
+		 * that swallows clicks on every dashboard button. */
+		position: relative;
+		width: auto;
+		height: auto;
 		text-align: center;
 		padding: 60px 20px;
 		color: var(--text-muted);

--- a/src/ui/partials/dashboard/IndicatorsSection.svelte
+++ b/src/ui/partials/dashboard/IndicatorsSection.svelte
@@ -529,6 +529,13 @@
 
 	/* ── Empty state ───────────────────────────────────── */
 	.empty-state {
+		/* Override Obsidian core's global `.empty-state` rule
+		 * (position:absolute; width:100%; height:100%; top:0) which would
+		 * otherwise turn this placeholder into a full-viewport overlay
+		 * that swallows clicks on every dashboard button. */
+		position: relative;
+		width: auto;
+		height: auto;
 		display: flex;
 		flex-direction: column;
 		align-items: center;


### PR DESCRIPTION
## Bug

The new **Financial Indicators** section (introduced in v1.3.0) and the **Commodities** tab use the class `.empty-state` for their placeholder. That collides with a global rule in Obsidian's `app.css`:

```css
.empty-state {
  position: absolute;
  width: 100%;
  height: 100%;
  top: 0;
  inset-inline-start: 0;
  display: flex;
  align-items: center;
  justify-content: center;
  flex-direction: column;
}
```

The Svelte-scoped selectors (`.empty-state.svelte-1jvpudc.svelte-1jvpudc` and the equivalent in `CommoditiesTab.svelte`) have higher specificity but **do not redeclare `position`**, so the core rule wins for that property. The placeholder div renders as a viewport-sized overlay anchored at (0, 0) and **swallows every click on the dashboard**: the Refresh button, tab switching, Add Budget / Add Target, and the Budgets/Targets toggles all become inert as soon as the empty state is visible.

This makes a brand-new ledger essentially unusable on the Overview tab — the user can see the KPIs but cannot interact with anything until they manually create a budget/target through some other entry point.

## Repro

1. Open the Beancount Dashboard with no `Indicator` events in `events.beancount` (a fresh ledger satisfies this). The "No budgets defined yet." placeholder is shown.
2. Try clicking any button on the page (Refresh, a tab, "Add Budget"). Nothing happens.
3. DevTools confirms the issue: at every button's center,

   ```js
   document.elementFromPoint(cx, cy)
   // -> <div class="empty-state svelte-1jvpudc">
   ```

   instead of the button itself.

The same applies to `CommoditiesTab` when no commodities have been declared.

## Fix

Add explicit `position: relative; width: auto; height: auto;` to both `.empty-state` rules in `IndicatorsSection.svelte` and `CommoditiesTab.svelte`, with a brief inline comment pointing at the colliding core rule. No visual change in the populated path; only restores expected layout when the placeholder is shown.

## Verification

After the fix, `elementFromPoint` at each dashboard button returns the button itself, and click handlers fire as expected (BQL queries run, tabs switch, Add Budget modal opens). Verified locally on Obsidian 1.12.7 with the v1.3.0 build of this plugin patched in place.

## Notes / alternatives

- A cleaner long-term fix would be to **rename the class** to something namespaced like `indicators-empty` / `commodities-empty` — that removes the collision at the source rather than counter-declaring against it. Happy to do that in a follow-up if preferred; I went with the minimal, single-property override here to keep the diff tiny and risk-free.
- Workaround for users currently on v1.3.0: a CSS snippet that resets `position`/`width`/`height` inside `.indicators-section .empty-state` and the commodities equivalent. Effective immediately without waiting for a release.