### PR TITLE
feat(commodities): show holdings, pin operating currency, sort by value

### DIFF
--- a/src/controllers/CommoditiesController.ts
+++ b/src/controllers/CommoditiesController.ts
@@ -8,6 +8,7 @@ import {
     parseCommoditiesListCSV,
     parseCommoditiesPriceDataCSV,
     parseCommodityDetailsCSV,
+    parseCommoditiesHoldingsCSV,
     validatePriceSource,
     validateLogoUrl,
     saveCommodityMetadata
@@ -41,6 +42,14 @@ export interface CommodityInfo {
     isPriceLatest?: boolean;
     /** The date of the last price record. */
     priceDate?: string | null;
+    /** Numeric quantity held in Asset accounts (always non-negative). */
+    holdings?: number;
+    /** Display string for holdings, e.g. "11.80 USD" or "30949 UYU". */
+    holdingsRaw?: string;
+    /** Holdings converted to operating currency, used for sort. */
+    valueInOperatingCurrency?: number;
+    /** True for the operating currency (highlighted and pinned to the top). */
+    isOperatingCurrency?: boolean;
 }
 
 /**
@@ -160,10 +169,11 @@ export class CommoditiesController {
             // Get operating currency from settings
             const operatingCurrency = this.plugin.settings.operatingCurrency || 'USD';
 
-            // Execute both queries in parallel
-            const [commoditiesCSV, priceDataCSV] = await Promise.all([
+            // Execute all three queries in parallel
+            const [commoditiesCSV, priceDataCSV, holdingsCSV] = await Promise.all([
                 this.plugin.runQuery(queries.getAllCommoditiesQuery()),
-                this.plugin.runQuery(queries.getCommoditiesPriceDataQuery(operatingCurrency))
+                this.plugin.runQuery(queries.getCommoditiesPriceDataQuery(operatingCurrency)),
+                this.plugin.runQuery(queries.getCommoditiesHoldingsQuery(operatingCurrency))
             ]);
 
             console.debug('[CommoditiesController] loadData: received CSV data');
@@ -171,12 +181,20 @@ export class CommoditiesController {
             // Parse CSV results
             const allSymbols = parseCommoditiesListCSV(commoditiesCSV);
             const priceDataMap = parseCommoditiesPriceDataCSV(priceDataCSV);
+            const holdingsMap = parseCommoditiesHoldingsCSV(holdingsCSV);
 
-            console.debug('[CommoditiesController] parsed', allSymbols.length, 'commodities and', priceDataMap.size, 'price entries');
+            console.debug(
+                '[CommoditiesController] parsed',
+                allSymbols.length, 'commodities,',
+                priceDataMap.size, 'price entries,',
+                holdingsMap.size, 'holdings entries'
+            );
 
-            // Merge data: iterate all commodities and enrich with price data
+            // Merge data: iterate all commodities and enrich with price + holdings data
             const commodities: CommodityInfo[] = allSymbols.map(symbol => {
                 const priceData = priceDataMap.get(symbol);
+                const holdingsData = holdingsMap.get(symbol);
+                const isOperatingCurrency = symbol === operatingCurrency;
 
                 return {
                     symbol,
@@ -191,11 +209,24 @@ export class CommoditiesController {
                     currentPrice: priceData?.price ? `${priceData.price} ${operatingCurrency}` : undefined,
                     logoUrl: priceData?.logo || null,
                     priceDate: priceData?.date || null,
-                    isPriceLatest: priceData?.isLatest || false
+                    isPriceLatest: priceData?.isLatest || false,
+                    holdings: holdingsData?.holdings ?? 0,
+                    holdingsRaw: holdingsData?.holdingsRaw || '',
+                    valueInOperatingCurrency: holdingsData?.valueOp ?? 0,
+                    isOperatingCurrency,
                 } as CommodityInfo;
             });
 
-            commodities.sort((a, b) => a.symbol.localeCompare(b.symbol));
+            // Sort: operating currency first, then by value desc, then alphabetical.
+            commodities.sort((a, b) => {
+                if (a.isOperatingCurrency !== b.isOperatingCurrency) {
+                    return a.isOperatingCurrency ? -1 : 1;
+                }
+                const va = a.valueInOperatingCurrency ?? 0;
+                const vb = b.valueInOperatingCurrency ?? 0;
+                if (va !== vb) return vb - va;
+                return a.symbol.localeCompare(b.symbol);
+            });
             this.commodities.set(commodities);
             this.lastUpdated.set(new Date());
 

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -174,6 +174,15 @@ export function getCommoditiesPriceDataQuery(currency: string): string {
 	return `SELECT last(date) AS date_, last(currency) AS currency_, round(getprice(last(currency), '${currency}'),2) AS price_, currency_meta(last(currency), 'logo') AS logo_, bool(today()-1<last(date)) AS islatest_ FROM #prices GROUP BY currency`;
 }
 
+/**
+ * Holdings per commodity in Asset accounts:
+ *   - units_  : raw inventory (e.g. "11.80 USD" or ",30949 UYU"), used for display
+ *   - valueOp_: same holdings converted to the operating currency, used for sort
+ */
+export function getCommoditiesHoldingsQuery(operatingCurrency: string): string {
+	return `SELECT currency, units(sum(position)) AS units_, convert(sum(position), '${operatingCurrency}') AS valueOp_ WHERE account ~ '^Assets' GROUP BY currency`;
+}
+
 
 export function getCommodityDetailsQuery(symbol: string): string {
 	return `SELECT name AS name_, last(meta) AS meta_, currency_meta(last(name),'logo') AS logo_, currency_meta(last(name), 'price') AS pricemetadata_, meta('filename') AS filename_, meta('lineno') AS lineno_ FROM #commodities WHERE name='${symbol}'`;

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -79,7 +79,7 @@
 	}
 </script>
 
-<div class="commodity-card-wrapper">
+<div class="commodity-card-wrapper" class:is-operating={commodity?.isOperatingCurrency}>
 	<button
 		class="commodity-card"
 		on:click={handleClick}
@@ -106,6 +106,9 @@
 					<span class="symbol-text"
 						>{commodity?.symbol || `UNKNOWN_${index}`}</span
 					>
+					{#if commodity?.isOperatingCurrency}
+						<span class="operating-badge" title="Operating currency for this ledger">Operating</span>
+					{/if}
 				</div>
 			</div>
 
@@ -138,6 +141,13 @@
 			{:else}
 				<div class="no-price-state">
 					<span class="no-price-text">Price unavailable</span>
+				</div>
+			{/if}
+
+			{#if commodity?.holdingsRaw}
+				<div class="holdings-row">
+					<span class="holdings-label">Holdings</span>
+					<span class="holdings-value">{commodity.holdingsRaw}</span>
 				</div>
 			{/if}
 		</div>
@@ -393,5 +403,51 @@
 
 	.commodity-card:hover .arrow-box {
 		transform: translateX(6px);
+	}
+
+	/* OPERATING-CURRENCY HIGHLIGHT */
+	.commodity-card-wrapper.is-operating {
+		border-color: var(--interactive-accent);
+		box-shadow: 0 0 0 1px var(--interactive-accent),
+			0 4px 14px rgba(0, 0, 0, 0.05);
+	}
+	.commodity-card-wrapper.is-operating::after {
+		opacity: 1;
+	}
+
+	.operating-badge {
+		display: inline-block;
+		margin-left: 8px;
+		padding: 2px 7px;
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--text-on-accent);
+		background: var(--interactive-accent);
+		border-radius: 999px;
+		vertical-align: middle;
+	}
+
+	/* HOLDINGS ROW */
+	.holdings-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		margin-top: 10px;
+		padding-top: 10px;
+		border-top: 1px dashed var(--background-modifier-border);
+		font-size: 12px;
+	}
+	.holdings-label {
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
+	}
+	.holdings-value {
+		color: var(--text-normal);
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
 	}
 </style>

--- a/src/utils/csvParsers.ts
+++ b/src/utils/csvParsers.ts
@@ -124,3 +124,66 @@ export function parseCommodityDetailsCSV(csv: string): {
         return defaultResult;
     }
 }
+
+/**
+ * Parses CSV from getCommoditiesHoldingsQuery into a Map keyed by currency symbol.
+ *
+ * Each row has shape `[currency, units_, valueOp_]` where `units_` is an inventory
+ * string like `"11.80 USD"` or `",30949 UYU"` (sign placement varies by sum sign)
+ * and `valueOp_` is the same holdings converted to the operating currency
+ * (e.g. `"471 UYU"`).
+ *
+ * We extract the absolute numeric magnitude from each (sign is always positive
+ * for asset balances in practice; the sign placement is a beanquery CSV quirk).
+ */
+export function parseCommoditiesHoldingsCSV(
+    csv: string
+): Map<string, { holdings: number; holdingsRaw: string; valueOp: number }> {
+    const map = new Map<string, { holdings: number; holdingsRaw: string; valueOp: number }>();
+
+    const extractNumber = (cell: string | undefined): number => {
+        if (!cell) return 0;
+        // Match the first signed/unsigned numeric value; ignore currency tokens.
+        const m = cell.match(/-?\d+(?:\.\d+)?/);
+        return m ? parseFloat(m[0]) : 0;
+    };
+
+    try {
+        const cleanCsv = csv.replace(/\r/g, '').trim();
+        if (!cleanCsv) return map;
+
+        const records: string[][] = parseCsv(cleanCsv, {
+            columns: false,
+            skip_empty_lines: true,
+            relax_column_count: true,
+        });
+
+        for (let i = 1; i < records.length; i++) {
+            const row = records[i];
+            if (row.length < 3) continue;
+
+            const currency = row[0]?.trim();
+            if (!currency) continue;
+
+            const unitsCell = row[1]?.trim() || '';
+            const valueCell = row[2]?.trim() || '';
+
+            const holdings = Math.abs(extractNumber(unitsCell));
+            const valueOp = Math.abs(extractNumber(valueCell));
+
+            // Display string: pick whichever non-empty side of the inventory string
+            // has the value (e.g. "11.80 USD" or "30949 UYU").
+            const holdingsRaw = unitsCell
+                .split(',')
+                .map(s => s.trim())
+                .find(s => /\d/.test(s)) || '';
+
+            map.set(currency, { holdings, holdingsRaw, valueOp });
+        }
+
+        return map;
+    } catch (e) {
+        console.error('Error parsing commodities holdings CSV:', e, 'CSV:', csv);
+        return map;
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,7 @@ export {
 	parseMetadataString,
 	debounce,
 } from './formatters';
-export { parseCommoditiesListCSV, parseCommoditiesPriceDataCSV, parseCommodityDetailsCSV } from './csvParsers';
+export { parseCommoditiesListCSV, parseCommoditiesPriceDataCSV, parseCommodityDetailsCSV, parseCommoditiesHoldingsCSV } from './csvParsers';
 export { buildAccountTree, getOpenAccounts, getPayees, getTags, getCommodities } from './accounts';
 export { getTransactionEntries, getBalanceEntries, getNoteEntries } from './journal';
 export {


### PR DESCRIPTION
## What this changes

Three small enhancements to the **Commodities** tab to surface what the user actually owns, instead of an alphabetical catalog of every declared symbol.

### 1. Operating currency is pinned to the top

The dashboard's operating currency (`settings.operatingCurrency`) is the natural \"home\" of a ledger; showing it first and styling it distinctly makes that relationship explicit. Right now it lands wherever the alphabet places it (UYU → near the bottom).

### 2. Other commodities sort by holdings value, descending

A user with cash and a tiny crypto allocation wants the cash-heavy line first, not BTC. Sort key: `valueInOperatingCurrency` desc, alphabetical tiebreaker for zero-holdings rows.

### 3. Each card shows a \"Holdings\" row

The raw inventory string (e.g. `11.80 USD`, `30949 UYU`) renders beneath the price; absent when the user holds none of that commodity.

## Before / after

**Before** (alphabetical, no holdings):
```
BTC    Price unavailable    [View]
PAXG   Price unavailable    [View]
USD    Price unavailable    [View]
UYU    1.00 UYU             [View]
XAU    Price unavailable    [View]
XMR    Price unavailable    [View]
```

**After** (operating pinned, sorted by value, holdings shown):
```
UYU [Operating]   1.00 UYU       Holdings: 30949 UYU      [View]
USD               39.94 UYU      Holdings: 11.80 USD      [View]
BTC               3134504.54 UYU                          [View]
PAXG              183730.85 UYU                           [View]
XAU               183730.85 UYU                           [View]
XMR               15395.49 UYU                            [View]
```

## Plumbing

- **New query** `getCommoditiesHoldingsQuery(operatingCurrency)` does a single BQL pass over `^Assets` postings, returning both `units(sum(position))` (raw inventory string) and `convert(sum(position), op)` (numeric value in operating currency).
- **New parser** `parseCommoditiesHoldingsCSV` extracts a numeric magnitude from the inventory cell. beanquery emits a sign-positional string like `,30949 UYU` for one direction of the sum; we treat as `|value|` since asset totals are non-negative in practice.
- **`CommodityInfo`** gains four optional fields: `holdings`, `holdingsRaw`, `valueInOperatingCurrency`, `isOperatingCurrency`. All optional → no breaking change for other consumers.
- **`CommoditiesController.loadData`** runs the new query inside the existing `Promise.all`, merges results into each `CommodityInfo`, and applies the new three-key sort.
- **`CommodityCard.svelte`** renders an `Operating` pill next to the symbol when applicable, a subtle accent border + outline for that card, and a `Holdings` row in `card-body`.

## Backwards compat

- New `CommodityInfo` fields are all optional. Existing consumers (CommodityDetailModal, services) ignore them.
- Sort change is observable but harmless — it just reorders the existing grid.
- Holdings query runs in parallel with existing queries; no additional latency on cold load.
- No CSS class renames or DOM restructuring beyond the new `Operating` badge and `holdings-row` block (additive).

## Verified locally

- Build passes (`tsc -noEmit && esbuild production`).
- Reload on Obsidian 1.12.7 yields zero console warnings/errors.
- All six cards render in a UYU-operating ledger with the expected order, holdings, and LIVE prices (prices fed via a custom `bean-price` replacement script that proxies CoinGecko + open.er-api.com — unrelated to this PR).
- `document.elementFromPoint(...)` at each button still returns the button itself (i.e. no regression of the empty-state collision fix proposed in #122).

## Notes

- This is independent of #122 (different files); they should merge in any order.
- The screenshots/output above come from a live test on the maintainer's actual ledger, not synthetic data — happy to provide screenshots if useful.