### PR TITLE
feat(commodities): add display toggles for holdings and OC equivalent

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,6 +45,11 @@ export interface BeancountPluginSettings {
     lastAutoPriceFetch: number;
     /** Bean-price command path (detected automatically). */
     beanPriceCommand: string;
+    // Commodity Display Settings
+    /** Show the holdings amount on commodity cards in the dashboard. */
+    showCommodityHoldings: boolean;
+    /** Also show the equivalent in the operating currency below the holdings amount. */
+    showCommodityHoldingsValue: boolean;
 }
 
 /**
@@ -70,7 +75,10 @@ export const DEFAULT_SETTINGS: BeancountPluginSettings = {
     autoPriceFetch: false,
     priceFetchIntervalHours: 24,
     lastAutoPriceFetch: 0,
-    beanPriceCommand: ''
+    beanPriceCommand: '',
+    // Commodity Display Settings
+    showCommodityHoldings: true,
+    showCommodityHoldingsValue: true
 }
 
 /**
@@ -261,6 +269,32 @@ export class BeancountSettingTab extends PluginSettingTab {
                 infoEl.style.opacity = '0.7';
                 infoEl.textContent = `Last automatic fetch: ${timeSince} (${lastFetchDate.toLocaleString()})`;
             }
+        }
+
+        // Commodities Display Settings Section
+        containerEl.createEl('h3', { text: 'Commodities Display' });
+
+        new Setting(containerEl)
+            .setName('Show holdings on commodity cards')
+            .setDesc('Display the holdings amount (e.g. "11.80 USD") below the price on each commodity card.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.showCommodityHoldings)
+                .onChange(async (value) => {
+                    this.plugin.settings.showCommodityHoldings = value;
+                    await this.plugin.saveSettings();
+                    this.display();
+                }));
+
+        if (this.plugin.settings.showCommodityHoldings) {
+            new Setting(containerEl)
+                .setName('Show operating-currency equivalent')
+                .setDesc('Below the holdings, also show the equivalent in the operating currency (e.g. "≈ 471 UYU"). Hidden for the operating currency itself.')
+                .addToggle(toggle => toggle
+                    .setValue(this.plugin.settings.showCommodityHoldingsValue)
+                    .onChange(async (value) => {
+                        this.plugin.settings.showCommodityHoldingsValue = value;
+                        await this.plugin.saveSettings();
+                    }));
         }
     }
 

--- a/src/ui/partials/dashboard/CommoditiesTab.svelte
+++ b/src/ui/partials/dashboard/CommoditiesTab.svelte
@@ -8,6 +8,13 @@
 	import CommodityCard from "./cards/CommodityCard.svelte";
 
 	export let controller: CommoditiesController;
+	export let plugin: any = null;
+
+	// Pull display settings (and operating currency) off the plugin instance
+	// so CommodityCard can render conditionally without reading plugin itself.
+	$: showHoldings = plugin?.settings?.showCommodityHoldings ?? true;
+	$: showHoldingsValue = plugin?.settings?.showCommodityHoldingsValue ?? true;
+	$: operatingCurrency = plugin?.settings?.operatingCurrency ?? "";
 
 	const dispatch = createEventDispatcher();
 
@@ -165,6 +172,9 @@
 				<CommodityCard
 					{commodity}
 					{index}
+					{showHoldings}
+					{showHoldingsValue}
+					{operatingCurrency}
 					on:click={handleCommodityClick}
 				/>
 			{/each}

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -5,8 +5,26 @@
 
 	export let commodity: CommodityInfo;
 	export let index: number = 0;
+	export let showHoldings: boolean = true;
+	export let showHoldingsValue: boolean = true;
+	export let operatingCurrency: string = "";
 
 	const dispatch = createEventDispatcher();
+
+	// Format the operating-currency equivalent (e.g. "≈ 471 UYU"). Uses the
+	// user's locale so thousands/decimals match other dashboard widgets.
+	$: equivalentLabel = (() => {
+		if (!showHoldings || !showHoldingsValue) return "";
+		if (commodity?.isOperatingCurrency) return "";
+		if (!operatingCurrency) return "";
+		const value = commodity?.valueInOperatingCurrency;
+		if (typeof value !== "number" || !isFinite(value) || value <= 0) return "";
+		const formatted = value.toLocaleString(undefined, {
+			minimumFractionDigits: 0,
+			maximumFractionDigits: 2,
+		});
+		return `≈ ${formatted} ${operatingCurrency}`;
+	})();
 
 	function handleClick() {
 		dispatch("click", { commodity });
@@ -144,11 +162,16 @@
 				</div>
 			{/if}
 
-			{#if commodity?.holdingsRaw}
+			{#if showHoldings && commodity?.holdingsRaw}
 				<div class="holdings-row">
 					<span class="holdings-label">Holdings</span>
 					<span class="holdings-value">{commodity.holdingsRaw}</span>
 				</div>
+				{#if equivalentLabel}
+					<div class="holdings-equivalent-row">
+						<span class="holdings-equivalent">{equivalentLabel}</span>
+					</div>
+				{/if}
 			{/if}
 		</div>
 
@@ -449,5 +472,17 @@
 		color: var(--text-normal);
 		font-weight: 600;
 		font-variant-numeric: tabular-nums;
+	}
+
+	.holdings-equivalent-row {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 2px;
+		font-size: 11px;
+	}
+	.holdings-equivalent {
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: 0.02em;
 	}
 </style>

--- a/src/ui/views/dashboard/UnifiedDashboardView.svelte
+++ b/src/ui/views/dashboard/UnifiedDashboardView.svelte
@@ -64,7 +64,7 @@
         {:else if activeTab === 'incomestatement'}
             <IncomeStatementTab controller={incomeStatementController} />
         {:else if activeTab === 'commodities'}
-            <CommoditiesTab controller={commoditiesController} on:openCommodity on:addCommodity />
+            <CommoditiesTab controller={commoditiesController} {plugin} on:openCommodity on:addCommodity />
         {/if}
     </div>
 </div>


### PR DESCRIPTION
## Summary

Adds two new General-tab settings that control the holdings rows on the
commodity cards added in #123:

- **Show holdings on commodity cards** (default: on) — toggle for the
  existing holdings-amount row (e.g. `Holdings 11.80 USD`).
- **Show operating-currency equivalent** (default: on, gated behind
  the first toggle) — adds a small `≈ N OC` row beneath the holdings
  on non-operating commodity cards. Suppressed for the operating
  currency itself, where the equivalence is tautological.

## Why

The holdings row shipped in #123 is useful but not always wanted —
some users prefer the leaner card. The operating-currency equivalent
turns the card into a quick "how much is this worth in my base?"
read without leaving the Commodities tab. Both default to on so the
post-#123 behaviour is preserved; users opt out via settings.

## Implementation

Settings flow:
`BeancountPluginSettings` → `CommoditiesTab` (via the `plugin` prop
already used elsewhere in `UnifiedDashboardView`) → `CommodityCard`.
No controller changes — `valueInOperatingCurrency` was already
populated in `CommoditiesController.loadData` from #123.

## Test plan

- [x] Build passes: \`npm run build\` (tsc + esbuild, no warnings).
- [x] Default settings render the same UI as before #123 + this PR
      together (holdings row + OC equivalent visible).
- [x] Toggling **Show holdings** off hides the row; toggling
      **Show equivalent** off keeps holdings, hides only the
      \`≈ N OC\` row.
- [x] Operating currency card never shows the equivalent row even
      when both toggles are on.
- [x] Verified live in Obsidian with 6 commodities; USD card shows
      \`Holdings 11.80 USD\` and \`≈ 475 UYU\` as expected; UYU
      (operating) card shows holdings only.

## Notes for reviewer

- No changes to BQL queries or the controller; this PR is purely a
  settings + Svelte rendering change.
- The new settings are additive to \`BeancountPluginSettings\` with
  defaults of \`true\`, so existing \`data.json\` files don't need
  migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)