### PR TITLE
feat(dashboard): add equivalent currencies row below primary values

### DIFF
--- a/src/controllers/CommoditiesController.ts
+++ b/src/controllers/CommoditiesController.ts
@@ -13,6 +13,7 @@ import {
     validateLogoUrl,
     saveCommodityMetadata
 } from '../utils/index';
+import { sanitizeEquivalentCurrencies } from '../utils/equivalents';
 import { PriceService } from '../services/price.service';
 import { Notice } from 'obsidian';
 
@@ -50,6 +51,12 @@ export interface CommodityInfo {
     valueInOperatingCurrency?: number;
     /** True for the operating currency (highlighted and pinned to the top). */
     isOperatingCurrency?: boolean;
+    /**
+     * Price of this commodity in each enabled equivalent currency (settings.equivalentCurrencies).
+     * Keyed by currency code, value is the converted price; empty when no equivalents are configured
+     * or when the commodity is itself the operating currency.
+     */
+    equivalents?: Record<string, number>;
 }
 
 /**
@@ -169,11 +176,26 @@ export class CommoditiesController {
             // Get operating currency from settings
             const operatingCurrency = this.plugin.settings.operatingCurrency || 'USD';
 
+            // Equivalents: same price query, re-issued per equivalent currency. Failures
+            // for one equivalent are swallowed so a missing price chain doesn't break
+            // the whole tab.
+            const equivalents = sanitizeEquivalentCurrencies(
+                this.plugin.settings.equivalentCurrencies,
+                operatingCurrency,
+            );
+
             // Execute all three queries in parallel
-            const [commoditiesCSV, priceDataCSV, holdingsCSV] = await Promise.all([
+            const [commoditiesCSV, priceDataCSV, holdingsCSV, ...equivalentCSVs] = await Promise.all([
                 this.plugin.runQuery(queries.getAllCommoditiesQuery()),
                 this.plugin.runQuery(queries.getCommoditiesPriceDataQuery(operatingCurrency)),
-                this.plugin.runQuery(queries.getCommoditiesHoldingsQuery(operatingCurrency))
+                this.plugin.runQuery(queries.getCommoditiesHoldingsQuery(operatingCurrency)),
+                ...equivalents.map(eq =>
+                    this.plugin.runQuery(queries.getCommoditiesPriceDataQuery(eq))
+                        .catch(err => {
+                            console.warn(`[CommoditiesController] equivalent '${eq}' failed:`, err);
+                            return '';
+                        })
+                ),
             ]);
 
             console.debug('[CommoditiesController] loadData: received CSV data');
@@ -182,6 +204,23 @@ export class CommoditiesController {
             const allSymbols = parseCommoditiesListCSV(commoditiesCSV);
             const priceDataMap = parseCommoditiesPriceDataCSV(priceDataCSV);
             const holdingsMap = parseCommoditiesHoldingsCSV(holdingsCSV);
+
+            // Build per-equivalent price maps: { 'USD' => Map(symbol => price), ... }
+            const equivalentPriceMaps = new Map<string, Map<string, number>>();
+            equivalents.forEach((eq, idx) => {
+                const csv = equivalentCSVs[idx];
+                if (!csv) {
+                    equivalentPriceMaps.set(eq, new Map());
+                    return;
+                }
+                const parsed = parseCommoditiesPriceDataCSV(csv);
+                const priceOnly = new Map<string, number>();
+                parsed.forEach((entry, symbol) => {
+                    const num = parseFloat(entry.price ?? '');
+                    if (isFinite(num)) priceOnly.set(symbol, num);
+                });
+                equivalentPriceMaps.set(eq, priceOnly);
+            });
 
             console.debug(
                 '[CommoditiesController] parsed',
@@ -195,6 +234,21 @@ export class CommoditiesController {
                 const priceData = priceDataMap.get(symbol);
                 const holdingsData = holdingsMap.get(symbol);
                 const isOperatingCurrency = symbol === operatingCurrency;
+
+                // Per-commodity equivalents: price of this symbol in each equivalent currency.
+                // Skipped for the operating-currency card (its self-price is meaningless).
+                const equivalentsMap: Record<string, number> = {};
+                if (!isOperatingCurrency) {
+                    for (const eq of equivalents) {
+                        const price = equivalentPriceMaps.get(eq)?.get(symbol);
+                        // A returned 0 here means BQL's getprice() found no chain to the
+                        // target currency — treat that as "no equivalent" rather than
+                        // rendering a misleading "≈ 0 CCY" line.
+                        if (typeof price === 'number' && isFinite(price) && price !== 0) {
+                            equivalentsMap[eq] = price;
+                        }
+                    }
+                }
 
                 return {
                     symbol,
@@ -214,6 +268,7 @@ export class CommoditiesController {
                     holdingsRaw: holdingsData?.holdingsRaw || '',
                     valueInOperatingCurrency: holdingsData?.valueOp ?? 0,
                     isOperatingCurrency,
+                    equivalents: equivalentsMap,
                 } as CommodityInfo;
             });
 

--- a/src/controllers/IncomeStatementController.ts
+++ b/src/controllers/IncomeStatementController.ts
@@ -7,6 +7,7 @@ import { parse as parseCsv } from 'csv-parse/sync';
 import { extractConvertedAmount, extractNonReportingCurrencies, parseAmount } from '../utils/index';
 import type { ChartConfiguration } from 'chart.js/auto';
 import { Logger } from '../utils/logger';
+import { sanitizeEquivalentCurrencies, collectEquivalents } from '../utils/equivalents';
 // Re-export AccountItem so IncomeStatementTab can import from here
 export type { AccountItem } from './BalanceSheetController';
 import type { AccountItem } from './BalanceSheetController';
@@ -47,6 +48,12 @@ export interface IncomeStatementState {
 	chartInterval: 'month' | 'week';
 	/** The active trend type shown in the Trends chart. */
 	chartTrendType: 'netprofit' | 'income' | 'expense';
+	/** Total income converted to each enabled equivalent currency (raw beancount sign — negative). */
+	totalIncomeEquivalents: Record<string, number>;
+	/** Total expenses converted to each enabled equivalent currency. */
+	totalExpensesEquivalents: Record<string, number>;
+	/** Net profit converted to each enabled equivalent currency (positive when income > expenses). */
+	netProfitEquivalents: Record<string, number>;
 }
 
 /**
@@ -79,6 +86,9 @@ export class IncomeStatementController {
 			chartLoading: false,
 			chartInterval: 'month' as const,
 			chartTrendType: 'netprofit' as const,
+			totalIncomeEquivalents: {},
+			totalExpensesEquivalents: {},
+			netProfitEquivalents: {},
 		});
 	}
 
@@ -444,6 +454,17 @@ export class IncomeStatementController {
 			// totalIncome is negative in beancount (credit accounts); compute conventional profit
 			const netProfit = -(totalIncome + totalExpenses);
 
+			// Equivalents are only meaningful for the 'convert' valuation method —
+			// cost/units don't have a single base, so equivalents would be misleading.
+			const equivalents = valuationMethod === 'convert'
+				? sanitizeEquivalentCurrencies(this.plugin.settings.equivalentCurrencies, reportingCurrency)
+				: [];
+			const [totalIncomeEquivalents, totalExpensesEquivalents, netProfitEquivalents] = await Promise.all([
+				collectEquivalents(this.plugin, equivalents, queries.getTotalIncomeQuery),
+				collectEquivalents(this.plugin, equivalents, queries.getTotalExpensesQuery),
+				collectEquivalents(this.plugin, equivalents, queries.getNetProfitQuery),
+			]);
+
 			let unconvertedWarning: string | null = null;
 			if (hasUnconvertedCommodities) {
 				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the first column, other currencies are displayed separately. Only ${reportingCurrency} amounts are included in totals.`;
@@ -468,6 +489,9 @@ export class IncomeStatementController {
 				chartLoading: true,
 				chartInterval: currentState.chartInterval,
 				chartTrendType: currentState.chartTrendType,
+				totalIncomeEquivalents,
+				totalExpensesEquivalents,
+				netProfitEquivalents,
 			});
 
 			// Load chart data

--- a/src/controllers/OverviewController.ts
+++ b/src/controllers/OverviewController.ts
@@ -5,6 +5,7 @@ import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
 import { parseSingleValue } from '../utils/index'; // Import helpers
 import { Logger } from '../utils/logger';
+import { sanitizeEquivalentCurrencies, collectEquivalents } from '../utils/equivalents';
 
 /**
  * Interface representing the state of the Overview dashboard.
@@ -24,6 +25,12 @@ export interface OverviewState {
 	savingsRate: string;
 	/** The reporting currency. */
 	currency: string;
+	/** Net worth, indexed by each enabled equivalent currency. Empty when none configured. */
+	netWorthEquivalents: Record<string, number>;
+	/** Monthly income, indexed by each enabled equivalent currency. */
+	monthlyIncomeEquivalents: Record<string, number>;
+	/** Monthly expenses, indexed by each enabled equivalent currency. */
+	monthlyExpensesEquivalents: Record<string, number>;
 }
 
 /**
@@ -54,6 +61,9 @@ export class OverviewController {
 			monthlyExpenses: '0.00 USD',
 			savingsRate: '0%',
 			currency: plugin.settings.operatingCurrency || 'USD',
+			netWorthEquivalents: {},
+			monthlyIncomeEquivalents: {},
+			monthlyExpensesEquivalents: {},
 		});
 	}
 
@@ -75,11 +85,26 @@ export class OverviewController {
 		}
 
 		try {
-			const [netWorthResult, incomeResult, expensesResult, savingsResult] = await Promise.all([
+			const equivalents = sanitizeEquivalentCurrencies(
+				this.plugin.settings.equivalentCurrencies,
+				reportingCurrency,
+			);
+			const fetchEquivalents = (factory: (c: string, r: number) => string) =>
+				equivalents.length === 0
+					? Promise.resolve({} as Record<string, number>)
+					: collectEquivalents(this.plugin, equivalents, factory);
+
+			const [
+				netWorthResult, incomeResult, expensesResult, savingsResult,
+				netWorthEquivalents, monthlyIncomeEquivalents, monthlyExpensesEquivalents,
+			] = await Promise.all([
 				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, 2)),
 				this.plugin.runQuery(queries.getThisMonthIncomeQuery(reportingCurrency, 2)),
 				this.plugin.runQuery(queries.getThisMonthExpensesQuery(reportingCurrency, 2)),
 				this.plugin.runQuery(queries.getThisMonthSavingsQuery(reportingCurrency, 2)),
+				fetchEquivalents(queries.getTotalWorthQuery),
+				fetchEquivalents(queries.getThisMonthIncomeQuery),
+				fetchEquivalents(queries.getThisMonthExpensesQuery),
 			]);
 
 			// Process KPI Data
@@ -97,6 +122,9 @@ export class OverviewController {
 				monthlyExpenses: `${expensesAmount.toFixed(2)} ${reportingCurrency}`,
 				savingsRate: incomeAmount > 0 ? `${((savingsNum / incomeAmount) * 100).toFixed(0)}%` : 'N/A',
 				currency: reportingCurrency,
+				netWorthEquivalents,
+				monthlyIncomeEquivalents,
+				monthlyExpensesEquivalents,
 			};
 
 			// Update the store with KPI data

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -62,6 +62,23 @@ export function getIncomeStatementQuery(currency: string): string {
 	return `SELECT account, convert(sum(position), '${currency}') WHERE account ~ '^(Income|Expenses)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
 }
 
+// All-time totals as a single number — used to fetch equivalents-row values
+// without re-running the full per-account hierarchy query for each currency.
+// Sign convention matches IncomeStatementState exactly: totalIncome keeps the
+// raw beancount sign (negative for credit accounts), totalExpenses is positive
+// (debit), netProfit is positive when income exceeds expenses.
+export function getTotalIncomeQuery(currency: string, rounding: number = 2): string {
+	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding}) AS _totalIncome WHERE account ~ '^Income' AND NOT close_date(account)`;
+}
+
+export function getTotalExpensesQuery(currency: string, rounding: number = 2): string {
+	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding}) AS _totalExpenses WHERE account ~ '^Expenses' AND NOT close_date(account)`;
+}
+
+export function getNetProfitQuery(currency: string, rounding: number = 2): string {
+	return `SELECT neg(round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding})) AS _netProfit WHERE account ~ '^(Income|Expenses)' AND NOT close_date(account)`;
+}
+
 export function getIncomeStatementQueryByCost(): string {
 	return `SELECT account, cost(sum(position)) WHERE account ~ '^(Income|Expenses)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,13 @@ export interface BeancountPluginSettings {
     beancountCommand: string;
     /** The primary currency for reporting and defaults. */
     operatingCurrency: string;
+    /**
+     * Additional currencies to display as equivalents beneath primary monetary
+     * values on the dashboard (e.g. ["USD", "BTC"] under each KPI). The primary
+     * base remains canonical for hierarchies, charts, modals and the ledger
+     * header — this list only affects the small "≈ N CCY" sub-row.
+     */
+    equivalentCurrencies: string[];
     /** Max transactions to fetch in the dashboard. */
     maxTransactionResults: number;
     /** Max entries to fetch in the journal. */
@@ -64,6 +71,7 @@ export const DEFAULT_SETTINGS: BeancountPluginSettings = {
     beancountFilePath: '',
     beancountCommand: '',
     operatingCurrency: 'USD',
+    equivalentCurrencies: [],
     maxTransactionResults: 2000,
     maxJournalResults: 1000,
     // BQL Code Block Settings
@@ -222,6 +230,8 @@ export class BeancountSettingTab extends PluginSettingTab {
                 })
             );
 
+        this.renderEquivalentCurrenciesEditor(containerEl);
+
         new Setting(containerEl)
             .setName('Debug mode')
             .setDesc('Enable debug logging to the console.')
@@ -342,6 +352,101 @@ export class BeancountSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     }
                 }));
+    }
+
+    /**
+     * Renders the multi-base "equivalent currencies" list editor in the
+     * General tab. Each entry adds a small "≈ N CCY" sub-row beneath
+     * primary monetary values on the dashboard. Defaults to an empty
+     * list, in which case no equivalents are shown anywhere.
+     */
+    private renderEquivalentCurrenciesEditor(containerEl: HTMLElement): void {
+        const list = this.plugin.settings.equivalentCurrencies ?? [];
+
+        const wrapper = containerEl.createDiv({ cls: 'beancount-equivalents-editor' });
+
+        new Setting(wrapper)
+            .setName('Equivalent currencies')
+            .setDesc(
+                'Show each primary value (KPI cards, income/expense totals, commodity prices) ' +
+                'with one extra line per entry, converted via the price table. ' +
+                'Leave empty to disable. Operating currency is excluded automatically.'
+            )
+            .addButton(button => button
+                .setButtonText('Add equivalent')
+                .setCta()
+                .onClick(async () => {
+                    const next = [...list, ''];
+                    this.plugin.settings.equivalentCurrencies = next;
+                    await this.plugin.saveSettings();
+                    this.display();
+                }));
+
+        list.forEach((entry, index) => {
+            const setting = new Setting(wrapper);
+            const validationEl = this.createValidationElement(wrapper);
+
+            setting
+                .setName(`Equivalent #${index + 1}`)
+                .addText(text => {
+                    text
+                        .setPlaceholder('USD')
+                        .setValue(entry)
+                        .onChange(async (value) => {
+                            const normalized = value.trim().toUpperCase();
+                            const current = this.plugin.settings.equivalentCurrencies ?? [];
+                            current[index] = normalized;
+                            this.plugin.settings.equivalentCurrencies = current;
+                            await this.plugin.saveSettings();
+
+                            if (!normalized) {
+                                validationEl.textContent = '';
+                                return;
+                            }
+                            const validation = this.validateEquivalentEntry(normalized, index);
+                            this.updateValidationDisplay(validationEl, validation);
+                        });
+
+                    if (entry) {
+                        const initial = this.validateEquivalentEntry(entry, index);
+                        this.updateValidationDisplay(validationEl, initial);
+                    }
+                    return text;
+                })
+                .addExtraButton(button => button
+                    .setIcon('trash-2')
+                    .setTooltip('Remove this equivalent')
+                    .onClick(async () => {
+                        const next = (this.plugin.settings.equivalentCurrencies ?? [])
+                            .filter((_, i) => i !== index);
+                        this.plugin.settings.equivalentCurrencies = next;
+                        await this.plugin.saveSettings();
+                        this.display();
+                    }));
+        });
+    }
+
+    /**
+     * Validates a single equivalent-currencies entry. Reuses the operating
+     * currency's format check, then layers list-specific rules: must not
+     * equal the operating currency, must be unique within the list.
+     */
+    private validateEquivalentEntry(currency: string, atIndex: number): { isValid: boolean; message: string } {
+        const formatCheck = this.validateCurrency(currency);
+        if (!formatCheck.isValid) return formatCheck;
+
+        const operating = (this.plugin.settings.operatingCurrency || '').toUpperCase();
+        if (operating && currency.toUpperCase() === operating) {
+            return { isValid: false, message: 'Already the operating currency — no equivalent needed.' };
+        }
+
+        const list = this.plugin.settings.equivalentCurrencies ?? [];
+        const seenAt = list.findIndex((e, i) => i !== atIndex && e.toUpperCase() === currency.toUpperCase());
+        if (seenAt >= 0) {
+            return { isValid: false, message: `Duplicate of entry #${seenAt + 1}.` };
+        }
+
+        return { isValid: true, message: '✅ Will be shown as an equivalent.' };
     }
 
     /**

--- a/src/ui/common/CardComponent.svelte
+++ b/src/ui/common/CardComponent.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
+	import EquivalentsRow from '../partials/dashboard/EquivalentsRow.svelte';
+
 	// Props for the card content
 	export let label: string;
 	export let value: string;
 	export let comparison: string | null = null; // Optional comparison text (e.g., "+5% vs last month")
 	export let icon: string | null = null; // Optional icon name (Lucide icon)
+	/**
+	 * Optional equivalents map for the multi-base "show equivalents" feature.
+	 * When non-empty, a sub-row of "≈ N CCY" entries is rendered below the
+	 * primary value. Empty / undefined hides the row entirely.
+	 */
+	export let equivalents: Record<string, number> = {};
 </script>
 
 <div class="kpi-card">
@@ -12,6 +20,7 @@
 	{/if}
 	<div class="kpi-label">{label}</div>
 	<div class="kpi-value">{value}</div>
+	<EquivalentsRow {equivalents} variant="kpi" align="start" />
 	<div class="kpi-comparison">{comparison || '&nbsp;'}</div> </div>
 
 <style>

--- a/src/ui/partials/dashboard/EquivalentsRow.svelte
+++ b/src/ui/partials/dashboard/EquivalentsRow.svelte
@@ -1,0 +1,72 @@
+<!-- src/ui/partials/dashboard/EquivalentsRow.svelte -->
+<script lang="ts">
+	export let equivalents: Record<string, number> = {};
+	/**
+	 * Visual variant. `kpi` matches the Overview KPI card type scale (slightly
+	 * larger), `compact` is used inside dense rows like income/expense totals
+	 * and commodity cards.
+	 */
+	export let variant: 'kpi' | 'compact' = 'compact';
+	/** Optional alignment override; defaults to inheriting block alignment. */
+	export let align: 'start' | 'end' | 'inherit' = 'inherit';
+
+	$: entries = Object.entries(equivalents ?? {})
+		.filter(([, value]) => typeof value === 'number' && isFinite(value));
+
+	// Pick decimal precision by magnitude so a 1,000 USD figure shows as
+	// "≈ 1,000" but a 0.012 BTC figure keeps enough significant digits.
+	function format(value: number): string {
+		const abs = Math.abs(value);
+		let max: number;
+		if (abs >= 1000) max = 0;
+		else if (abs >= 1) max = 2;
+		else if (abs >= 0.01) max = 4;
+		else if (abs >= 0.0001) max = 6;
+		else max = 8;
+		return value.toLocaleString(undefined, {
+			minimumFractionDigits: 0,
+			maximumFractionDigits: max,
+		});
+	}
+</script>
+
+{#if entries.length > 0}
+	<div
+		class="equivalents-row"
+		class:variant-kpi={variant === 'kpi'}
+		class:variant-compact={variant === 'compact'}
+		class:align-end={align === 'end'}
+		class:align-start={align === 'start'}
+	>
+		{#each entries as [currency, value], i}
+			<span class="equivalent">≈ {format(value)} {currency}</span>
+			{#if i < entries.length - 1}
+				<span class="separator" aria-hidden="true">·</span>
+			{/if}
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.equivalents-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		align-items: baseline;
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: 0.02em;
+	}
+	.equivalents-row.align-end { justify-content: flex-end; }
+	.equivalents-row.align-start { justify-content: flex-start; }
+
+	.variant-kpi { font-size: var(--font-ui-small); margin-top: 2px; }
+	.variant-compact { font-size: 11px; margin-top: 2px; }
+
+	.equivalent { white-space: nowrap; }
+
+	.separator {
+		color: var(--text-faint);
+		opacity: 0.7;
+	}
+</style>

--- a/src/ui/partials/dashboard/IncomeStatementTab.svelte
+++ b/src/ui/partials/dashboard/IncomeStatementTab.svelte
@@ -5,6 +5,7 @@
 	import { Logger } from '../../../utils/logger';
 	import SunburstChart from '../../common/SunburstChart.svelte';
 	import ChartComponent from '../../common/ChartComponent.svelte';
+	import EquivalentsRow from './EquivalentsRow.svelte';
 
 	// Chart selector
 	let selectedChart: 'trend' | 'total' = 'trend';
@@ -21,6 +22,7 @@
 		hasUnconvertedCommodities: false, unconvertedWarning: null, valuationMethod: 'convert',
 		chartConfig: null, chartError: null, chartLoading: false, chartInterval: 'month',
 		chartTrendType: 'netprofit',
+		totalIncomeEquivalents: {}, totalExpensesEquivalents: {}, netProfitEquivalents: {},
 	});
 	$: stateStore = controller ? controller.state : placeholderState;
 	$: state = $stateStore;
@@ -323,7 +325,10 @@
 					</table>
 					<div class="section-total">
 						<span>Total Income</span>
-						<span class="total-amount">{state.totalIncome.toFixed(2)} {state.currency}</span>
+						<div class="total-amount-stack">
+							<span class="total-amount">{state.totalIncome.toFixed(2)} {state.currency}</span>
+							<EquivalentsRow equivalents={state.totalIncomeEquivalents} variant="compact" align="end" />
+						</div>
 					</div>
 				</div>
 
@@ -365,7 +370,10 @@
 					</table>
 					<div class="section-total">
 						<span>Total Expenses</span>
-						<span class="total-amount">{state.totalExpenses.toFixed(2)} {state.currency}</span>
+						<div class="total-amount-stack">
+							<span class="total-amount">{state.totalExpenses.toFixed(2)} {state.currency}</span>
+							<EquivalentsRow equivalents={state.totalExpensesEquivalents} variant="compact" align="end" />
+						</div>
 					</div>
 				</div>
 			</div>
@@ -373,9 +381,12 @@
 			<!-- Net Profit Summary -->
 			<div class="net-profit-row">
 				<span class="net-profit-label">Net Profit</span>
-				<span class="net-profit-value {netProfitClass(state.netProfit)}">
-					{state.netProfit.toFixed(2)} {state.currency}
-				</span>
+				<div class="net-profit-stack">
+					<span class="net-profit-value {netProfitClass(state.netProfit)}">
+						{state.netProfit.toFixed(2)} {state.currency}
+					</span>
+					<EquivalentsRow equivalents={state.netProfitEquivalents} variant="compact" align="end" />
+				</div>
 			</div>
 		</div>
 	{/if}
@@ -820,6 +831,15 @@
 
 	.total-amount.positive {
 		color: var(--color-green);
+	}
+
+	/* Stack the primary total above the optional equivalents sub-row. */
+	.total-amount-stack,
+	.net-profit-stack {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 2px;
 	}
 
 	/* Net profit row */

--- a/src/ui/partials/dashboard/OverviewTab.svelte
+++ b/src/ui/partials/dashboard/OverviewTab.svelte
@@ -27,6 +27,9 @@
 		monthlyExpenses: '0.00 USD',
 		savingsRate: '0%',
 		currency: 'USD',
+		netWorthEquivalents: {},
+		monthlyIncomeEquivalents: {},
+		monthlyExpensesEquivalents: {},
 	});
 
 	// 2. Use a reactive statement ($:) to update the local store variable
@@ -96,9 +99,9 @@
 		</div>
 		
 		<div class="kpi-grid">
-			<CardComponent label="Total Balance" value={state.netWorth} comparison="Assets minus liabilities" />
-			<CardComponent label="Monthly Income" value={state.monthlyIncome} comparison="Current month earnings" />
-			<CardComponent label="Monthly Expenses" value={state.monthlyExpenses} comparison="Current month spending" />
+			<CardComponent label="Total Balance" value={state.netWorth} equivalents={state.netWorthEquivalents} comparison="Assets minus liabilities" />
+			<CardComponent label="Monthly Income" value={state.monthlyIncome} equivalents={state.monthlyIncomeEquivalents} comparison="Current month earnings" />
+			<CardComponent label="Monthly Expenses" value={state.monthlyExpenses} equivalents={state.monthlyExpensesEquivalents} comparison="Current month spending" />
 			<CardComponent label="Savings Rate" value={state.savingsRate} comparison="Income minus expenses" />
 		</div>
 

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -2,12 +2,15 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import type { CommodityInfo } from "../../../../controllers/CommoditiesController";
+	import EquivalentsRow from "../EquivalentsRow.svelte";
 
 	export let commodity: CommodityInfo;
 	export let index: number = 0;
 	export let showHoldings: boolean = true;
 	export let showHoldingsValue: boolean = true;
 	export let operatingCurrency: string = "";
+
+	$: priceEquivalents = commodity?.equivalents ?? {};
 
 	const dispatch = createEventDispatcher();
 
@@ -156,6 +159,7 @@
 						>{commodity.currentPrice.split(" ")[1] || ""}</span
 					>
 				</div>
+				<EquivalentsRow equivalents={priceEquivalents} variant="compact" align="start" />
 			{:else}
 				<div class="no-price-state">
 					<span class="no-price-text">Price unavailable</span>

--- a/src/utils/equivalents.ts
+++ b/src/utils/equivalents.ts
@@ -1,0 +1,67 @@
+// src/utils/equivalents.ts
+
+import type BeancountPlugin from '../main';
+import { parseSingleValue } from './index';
+import { Logger } from './logger';
+
+const CURRENCY_FORMAT_RE = /^[A-Z][A-Z0-9'._-]*$/;
+
+/**
+ * Normalizes the user-configured `equivalentCurrencies` list into a clean,
+ * deduped array, dropping invalid entries and the operating currency itself.
+ * Returns an empty array when nothing is configured.
+ */
+export function sanitizeEquivalentCurrencies(
+    raw: string[] | undefined | null,
+    operatingCurrency: string,
+): string[] {
+    if (!raw || raw.length === 0) return [];
+    const op = (operatingCurrency || '').toUpperCase();
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const entry of raw) {
+        const code = (entry ?? '').trim().toUpperCase();
+        if (!code) continue;
+        if (!CURRENCY_FORMAT_RE.test(code)) continue;
+        if (code === op) continue;
+        if (seen.has(code)) continue;
+        seen.add(code);
+        out.push(code);
+    }
+    return out;
+}
+
+/**
+ * Runs the same single-value query factory against each equivalent currency
+ * in parallel and returns a `{ currency: number }` map. Failures for an
+ * individual currency are logged and dropped — the dashboard should still
+ * render the primary value even if one equivalent's price chain is missing.
+ *
+ * The factory shape matches the existing query helpers in queries/index.ts,
+ * which all accept (currency, rounding) and return a single-projection BQL
+ * string compatible with parseSingleValue.
+ */
+export async function collectEquivalents(
+    plugin: BeancountPlugin,
+    equivalents: string[],
+    factory: (currency: string, rounding: number) => string,
+    rounding: number = 2,
+): Promise<Record<string, number>> {
+    if (equivalents.length === 0) return {};
+    const entries = await Promise.all(equivalents.map(async (currency) => {
+        try {
+            const result = await plugin.runQuery(factory(currency, rounding));
+            const num = parseFloat(parseSingleValue(result));
+            if (!isFinite(num)) return null;
+            return [currency, num] as [string, number];
+        } catch (e) {
+            Logger.warn(`Equivalent currency '${currency}' query failed:`, e);
+            return null;
+        }
+    }));
+    const out: Record<string, number> = {};
+    for (const entry of entries) {
+        if (entry) out[entry[0]] = entry[1];
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary

Adds a small `≈ N CCY · ≈ N CCY` sub-row beneath KPI cards (Total Balance, Monthly Income, Monthly Expenses), Income Statement section totals (Total Income, Total Expenses, Net Profit), and Commodity card prices. Driven by a new `equivalentCurrencies: string[]` setting, default `[]` (feature is fully invisible until the user opts in).

The use case is **comparison** ("see UYU and USD side by side"), not switching. A read-only sub-row delivers that with no impact on hierarchies, charts, modals, or the ledger header — those remain canonically tied to `operatingCurrency`.

## Implementation notes

- **Settings UI:** list editor in the General tab with per-row inline validation (currency-format regex, reject duplicates, reject equality with `operatingCurrency`). Reuses the existing `validateCurrency()` format check.
- **Query layer:** no factory rewrites. Existing factories (`getTotalWorth`, `getThisMonth{Income,Expenses}`, `getCommoditiesPriceData`) already accept a currency argument; we re-issue them per equivalent in parallel. New lightweight totals factories were added for the Income Statement (`getTotalIncome`, `getTotalExpenses`, `getNetProfit`) to avoid re-running the per-account hierarchy query for each equivalent.
- **Failure isolation:** a missing price chain for one equivalent is caught and logged; the dashboard still renders the primary value and any other equivalents that did resolve.
- **Sign convention** for Income Statement equivalents matches the existing state fields exactly (totalIncome keeps raw beancount sign, netProfit is positive when income > expenses).
- **Commodity-card equivalents** skip the operating-currency card and drop zero-priced entries (BQL `getprice()` returns 0 when no chain is found — rendering "≈ 0 BTC" would mislead).
- **Cost / Units valuation methods** on the Income Statement get an empty equivalents map by design; FX equivalents are only meaningful for the `convert` method.

## Scope deliberately excluded

- Balance Sheet sunburst-center totals — the user already sees the net-worth equivalent on the Overview KPI, and `SunburstChart` is a chart, not a primary text value.
- Per-tab base selector (option B in the design) — only worth building if the equivalents row turns out to be insufficient after a week or two of real use.

## Test plan

- [x] Default `equivalentCurrencies: []` → zero behavioural change anywhere in the dashboard.
- [x] Set `["USD", "BTC"]` with operating `UYU`: KPIs render `≈ 780.94 USD · ≈ 0.01 BTC` under Total Balance; Income Statement totals + net profit show equivalents; commodity cards show per-currency prices.
- [x] Operating-currency card (e.g. UYU) does not show an equivalents row.
- [x] Currencies with no price chain (e.g. USD → BTC) are dropped silently rather than rendering "≈ 0 BTC".
- [x] Settings UI rejects duplicate entries and the operating currency itself with inline error.
- [x] No console errors on plugin reload.