### PR TITLE
feat(recurring): inline CRUD rules editor in settings + validation

### DIFF
--- a/src/services/recurring.service.ts
+++ b/src/services/recurring.service.ts
@@ -178,6 +178,122 @@ export function occurrencesInWindow(
 }
 
 /**
+ * Format a single rule as a Beancount `custom "recurring"` line.
+ * Round-trip with `parseRecurringFile` is exact for valid rules.
+ */
+export function formatRecurringRule(rule: RecurringRule): string {
+    const amountStr = Number.isInteger(rule.amount)
+        ? rule.amount.toString()
+        : rule.amount.toString();
+    return `${rule.startDate} custom "recurring" "${rule.nickname}" "${rule.cadence}" ` +
+        `"${rule.expenseAccount}" "${rule.fundingAccount}" ${amountStr} ${rule.currency}`;
+}
+
+/**
+ * Take an original file's content plus a desired list of rules and
+ * produce the new file content. Lines whose 1-based number matches a
+ * rule's `sourceLine` are replaced in-place with the new line; lines
+ * that are no longer represented (deleted rule) are dropped; new rules
+ * (no sourceLine, or sourceLine larger than the original line count)
+ * are appended at the end with a leading blank line for breathing room.
+ *
+ * Comments, blank lines and any other directives stay exactly where
+ * they were — this is a surgical edit, not a full re-emit.
+ */
+export function applyRecurringEdits(
+    originalContent: string,
+    rules: RecurringRule[],
+): string {
+    const originalLines = originalContent.split(/\r?\n/);
+    const trailingNewline = originalContent.endsWith('\n');
+
+    // Find the original recurring lines by re-parsing — gives us the set
+    // of line indices that are eligible for rewrite or removal.
+    const originalRules = parseRecurringFile(originalContent);
+    const originalLineIndices = new Set(
+        originalRules.map(r => (r.sourceLine ?? 0) - 1).filter(i => i >= 0),
+    );
+
+    // Map from original 1-based source line → desired rule (or undefined = delete).
+    const byLine = new Map<number, RecurringRule | undefined>();
+    for (const r of rules) {
+        if (typeof r.sourceLine === 'number' && r.sourceLine >= 1 && originalLineIndices.has(r.sourceLine - 1)) {
+            byLine.set(r.sourceLine, r);
+        }
+    }
+    // Lines originally containing a rule but not in `rules` => delete.
+    for (const idx of originalLineIndices) {
+        if (!byLine.has(idx + 1)) byLine.set(idx + 1, undefined);
+    }
+
+    // Walk lines, applying edits.
+    const out: string[] = [];
+    for (let i = 0; i < originalLines.length; i++) {
+        if (byLine.has(i + 1)) {
+            const desired = byLine.get(i + 1);
+            if (desired) out.push(formatRecurringRule(desired));
+            // else: deleted, skip the line entirely
+        } else {
+            out.push(originalLines[i]);
+        }
+    }
+
+    // Append new rules (those without a known sourceLine).
+    const appended = rules.filter(r =>
+        typeof r.sourceLine !== 'number' || !originalLineIndices.has((r.sourceLine ?? 0) - 1)
+    );
+    if (appended.length > 0) {
+        if (out.length > 0 && out[out.length - 1].trim() !== '') out.push('');
+        for (const r of appended) {
+            out.push(formatRecurringRule(r));
+        }
+    }
+
+    let result = out.join('\n');
+    if (trailingNewline && !result.endsWith('\n')) result += '\n';
+    return result;
+}
+
+/**
+ * Returns parser diagnostics for a file: which lines look like they
+ * intend to be `custom "recurring"` directives but failed validation,
+ * and why. A line is flagged when it contains the word `"recurring"`
+ * but doesn't match the full directive regex or has an unknown cadence.
+ */
+export interface RecurringValidationIssue {
+    line: number;
+    text: string;
+    reason: string;
+}
+
+export function validateRecurringFile(content: string): RecurringValidationIssue[] {
+    const issues: RecurringValidationIssue[] = [];
+    const lines = content.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+        const raw = lines[i];
+        const trimmed = raw.trim();
+        if (!trimmed || trimmed.startsWith(';')) continue;
+        if (!/custom\s+"recurring"/.test(trimmed)) continue;
+
+        const m = RECURRING_DIRECTIVE.exec(trimmed);
+        if (!m) {
+            issues.push({ line: i + 1, text: trimmed, reason: 'directive shape does not match expected format' });
+            continue;
+        }
+        const cadence = m[3];
+        if (!CADENCES.has(cadence as RecurringCadence)) {
+            issues.push({ line: i + 1, text: trimmed, reason: `unknown cadence "${cadence}" (expected one of: ${Array.from(CADENCES).join(', ')})` });
+            continue;
+        }
+        const amount = parseFloat(m[6]);
+        if (!isFinite(amount)) {
+            issues.push({ line: i + 1, text: trimmed, reason: `amount "${m[6]}" is not a finite number` });
+        }
+    }
+    return issues;
+}
+
+/**
  * Flat, date-sorted list of occurrences across all rules within
  * `lookaheadDays` from `today` (inclusive). The default `today` is
  * the local date in YYYY-MM-DD; callers can override for testing.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,9 @@
 // src/settings.ts
 
-import { App, PluginSettingTab, Setting, Notice } from 'obsidian';
+import { App, PluginSettingTab, Setting, Notice, FuzzySuggestModal, TFile } from 'obsidian';
 import type BeancountPlugin from './main';
 import ConnectionSettings from './ui/partials/settings/ConnectionSettings.svelte';
+import RecurringRulesEditor from './ui/partials/settings/RecurringRulesEditor.svelte';
 import { updateOperatingCurrency } from './utils/index';
 
 /**
@@ -327,6 +328,16 @@ export class BeancountSettingTab extends PluginSettingTab {
                 .onChange(async (value) => {
                     this.plugin.settings.recurringFilePath = value.trim();
                     await this.plugin.saveSettings();
+                }))
+            .addExtraButton(btn => btn
+                .setIcon('folder-open')
+                .setTooltip('Browse vault for a .beancount file')
+                .onClick(() => {
+                    new RecurringFilePickerModal(this.app, async (path) => {
+                        this.plugin.settings.recurringFilePath = path;
+                        await this.plugin.saveSettings();
+                        this.display();
+                    }).open();
                 }));
 
         new Setting(containerEl)
@@ -342,6 +353,21 @@ export class BeancountSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     }
                 }));
+
+        // Inline rules editor — Svelte component owns its own load/save lifecycle.
+        const editorMount = containerEl.createDiv({ cls: 'beancount-recurring-editor-mount' });
+        const editor = new RecurringRulesEditor({
+            target: editorMount,
+            props: { plugin: this.plugin },
+        });
+        editor.$on('saved', async () => {
+            // Trigger a workspace event that the unified dashboard view
+            // subscribes to (best-effort — if no dashboard is open, the
+            // event is a no-op).
+            try {
+                this.app.workspace.trigger('beancount:recurring-rules-updated');
+            } catch (_) { /* defensive */ }
+        });
     }
 
     /**
@@ -887,5 +913,29 @@ export class BeancountSettingTab extends PluginSettingTab {
             }
         `;
         document.head.appendChild(style);
+    }
+}
+
+/**
+ * Fuzzy file picker for the recurring-file path. Lists every .beancount
+ * file in the vault; selecting one writes its vault-relative path back
+ * via the supplied callback.
+ */
+class RecurringFilePickerModal extends FuzzySuggestModal<TFile> {
+    constructor(app: App, private onPick: (path: string) => void) {
+        super(app);
+        this.setPlaceholder('Pick a .beancount file…');
+    }
+
+    getItems(): TFile[] {
+        return this.app.vault.getFiles().filter(f => f.extension === 'beancount');
+    }
+
+    getItemText(item: TFile): string {
+        return item.path;
+    }
+
+    onChooseItem(item: TFile): void {
+        this.onPick(item.path);
     }
 }

--- a/src/ui/partials/settings/RecurringRulesEditor.svelte
+++ b/src/ui/partials/settings/RecurringRulesEditor.svelte
@@ -342,18 +342,17 @@
 
 					<label class="field currency">
 						<span>Currency</span>
-						<input
-							type="text"
-							list="recurring-currencies-{rule._localId}"
-							placeholder="USD"
+						<select
 							bind:value={rule.currency}
-							on:input={markDirty}
-						/>
-						<datalist id="recurring-currencies-{rule._localId}">
+							on:change={markDirty}
+						>
+							{#if rule.currency && !currencies.includes(rule.currency)}
+								<option value={rule.currency}>{rule.currency}</option>
+							{/if}
 							{#each currencies as c}
-								<option value={c} />
+								<option value={c}>{c}</option>
 							{/each}
-						</datalist>
+						</select>
 					</label>
 
 					<label class="field date">

--- a/src/ui/partials/settings/RecurringRulesEditor.svelte
+++ b/src/ui/partials/settings/RecurringRulesEditor.svelte
@@ -1,0 +1,494 @@
+<!-- src/ui/partials/settings/RecurringRulesEditor.svelte -->
+<script lang="ts">
+	import { onMount, createEventDispatcher } from 'svelte';
+	import { Notice, MarkdownView } from 'obsidian';
+	import {
+		parseRecurringFile,
+		applyRecurringEdits,
+		validateRecurringFile,
+		occurrencesInWindow,
+		type RecurringRule,
+		type RecurringCadence,
+	} from '../../../services/recurring.service';
+	import { getOpenAccounts } from '../../../utils/accounts';
+	import { getAllCurrenciesQuery } from '../../../queries/index';
+	import { parse as parseCsv } from 'csv-parse/sync';
+	import { Logger } from '../../../utils/logger';
+
+	export let plugin: any;
+
+	type Editable = RecurringRule & { _localId: string; _draft?: boolean };
+
+	const CADENCES: RecurringCadence[] = [
+		'daily', 'weekly', 'biweekly', 'monthly', 'quarterly', 'semiannual', 'yearly',
+	];
+
+	let rules: Editable[] = [];
+	let originalContent: string = '';
+	let resolvedPath: string = '';
+	let accounts: string[] = [];
+	let currencies: string[] = [];
+	let dirty = false;
+	let loading = false;
+	let saveError: string | null = null;
+
+	const dispatch = createEventDispatcher();
+
+	function newId(): string {
+		return Math.random().toString(36).slice(2, 9);
+	}
+
+	function resolvePath(): string {
+		const explicit = plugin.settings.recurringFilePath?.trim();
+		if (explicit) return explicit;
+		const folder = plugin.settings.structuredFolderName?.trim() || 'Finances';
+		return `${folder}/recurring.beancount`;
+	}
+
+	async function loadFile() {
+		loading = true;
+		saveError = null;
+		try {
+			resolvedPath = resolvePath();
+			const adapter = plugin.app.vault.adapter;
+			if (!(await adapter.exists(resolvedPath))) {
+				originalContent = '';
+				rules = [];
+				dirty = false;
+				return;
+			}
+			originalContent = await adapter.read(resolvedPath);
+			const parsed = parseRecurringFile(originalContent);
+			rules = parsed.map(r => ({ ...r, _localId: newId() }));
+			dirty = false;
+		} catch (e) {
+			saveError = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadAutocompleteSources() {
+		try {
+			const [accs, csv] = await Promise.all([
+				getOpenAccounts(plugin),
+				plugin.runQuery(getAllCurrenciesQuery()).catch(() => ''),
+			]);
+			accounts = accs ?? [];
+			if (csv) {
+				const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+				const fetched = rows.map((r: any) => r['currency_']).filter(Boolean) as string[];
+				if (fetched.length > 0) currencies = Array.from(new Set(fetched));
+			}
+			const op = plugin.settings.operatingCurrency;
+			if (op && !currencies.includes(op)) currencies.unshift(op);
+		} catch (e) {
+			Logger.log('[RecurringRulesEditor] failed to load autocomplete sources', e);
+		}
+	}
+
+	function todayIso(): string {
+		return new Date().toISOString().slice(0, 10);
+	}
+
+	function addRule() {
+		const op = plugin.settings.operatingCurrency || 'USD';
+		rules = [...rules, {
+			_localId: newId(),
+			_draft: true,
+			nickname: '',
+			cadence: 'monthly',
+			expenseAccount: '',
+			fundingAccount: '',
+			amount: 0,
+			currency: op,
+			startDate: todayIso(),
+		}];
+		dirty = true;
+	}
+
+	function removeRule(localId: string) {
+		rules = rules.filter(r => r._localId !== localId);
+		dirty = true;
+	}
+
+	function markDirty() {
+		dirty = true;
+	}
+
+	function ruleIsValid(r: Editable): { ok: boolean; reason?: string } {
+		if (!r.nickname.trim()) return { ok: false, reason: 'nickname required' };
+		if (!/^[a-zA-Z][a-zA-Z0-9 ._-]*$/.test(r.nickname.trim())) return { ok: false, reason: 'nickname: letters, digits, space, . _ -' };
+		if (!CADENCES.includes(r.cadence)) return { ok: false, reason: 'invalid cadence' };
+		if (!r.expenseAccount.trim()) return { ok: false, reason: 'destination account required' };
+		if (!r.fundingAccount.trim()) return { ok: false, reason: 'funding account required' };
+		if (!isFinite(r.amount) || r.amount === 0) return { ok: false, reason: 'amount must be a non-zero number' };
+		if (!/^[A-Z][A-Z0-9'._-]*$/.test(r.currency.trim())) return { ok: false, reason: 'invalid currency code' };
+		if (!/^\d{4}-\d{2}-\d{2}$/.test(r.startDate.trim())) return { ok: false, reason: 'start-date must be YYYY-MM-DD' };
+		return { ok: true };
+	}
+
+	function previewOccurrences(r: Editable): string[] {
+		const v = ruleIsValid(r);
+		if (!v.ok) return [];
+		const today = todayIso();
+		// One year window — enough to surface 3 occurrences for any cadence.
+		const to = (() => {
+			const d = new Date(today + 'T00:00:00Z');
+			d.setUTCFullYear(d.getUTCFullYear() + 1);
+			return d.toISOString().slice(0, 10);
+		})();
+		return occurrencesInWindow(r as RecurringRule, today, to).slice(0, 3);
+	}
+
+	async function save() {
+		saveError = null;
+		const invalid = rules.find(r => !ruleIsValid(r).ok);
+		if (invalid) {
+			saveError = `Rule "${invalid.nickname || '(unnamed)'}" is invalid: ${ruleIsValid(invalid).reason}`;
+			return;
+		}
+		try {
+			const adapter = plugin.app.vault.adapter;
+			const sourceContent = originalContent || '';
+			const cleanRules: RecurringRule[] = rules.map(r => ({
+				nickname: r.nickname.trim(),
+				cadence: r.cadence,
+				expenseAccount: r.expenseAccount.trim(),
+				fundingAccount: r.fundingAccount.trim(),
+				amount: r.amount,
+				currency: r.currency.trim().toUpperCase(),
+				startDate: r.startDate,
+				sourceLine: r._draft ? undefined : r.sourceLine,
+			}));
+			const newContent = applyRecurringEdits(sourceContent, cleanRules);
+			await adapter.write(resolvedPath, newContent);
+			new Notice('Recurring rules saved.');
+			dispatch('saved');
+			await loadFile();
+		} catch (e) {
+			saveError = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	function validate() {
+		if (!originalContent) {
+			new Notice('No file loaded yet.');
+			return;
+		}
+		const issues = validateRecurringFile(originalContent);
+		if (issues.length === 0) {
+			new Notice('No issues found.');
+		} else {
+			const summary = issues.slice(0, 5).map(i => `L${i.line}: ${i.reason}`).join('\n');
+			const more = issues.length > 5 ? `\n…and ${issues.length - 5} more` : '';
+			new Notice(`${issues.length} issue${issues.length === 1 ? '' : 's'}:\n${summary}${more}`, 10000);
+		}
+	}
+
+	async function openFileAtLine(line: number | undefined) {
+		try {
+			const file = plugin.app.vault.getAbstractFileByPath(resolvedPath);
+			if (!file) {
+				new Notice(`File not found: ${resolvedPath}`);
+				return;
+			}
+			const leaf = plugin.app.workspace.getLeaf(true);
+			await leaf.openFile(file as any);
+			if (typeof line === 'number') {
+				const view = leaf.view;
+				if (view instanceof MarkdownView && view.editor) {
+					view.editor.setCursor({ line: Math.max(0, line - 1), ch: 0 });
+					view.editor.scrollIntoView({ from: { line: line - 1, ch: 0 }, to: { line: line - 1, ch: 0 } }, true);
+				}
+			}
+		} catch (e) {
+			new Notice(`Could not open file: ${e instanceof Error ? e.message : String(e)}`);
+		}
+	}
+
+	$: filteredAccountSuggest = (q: string, prefix: 'Expenses' | 'Assets' | 'Income' | '' = '') => {
+		const lowered = q.toLowerCase();
+		return accounts
+			.filter(a => (prefix === '' || a.startsWith(prefix)) && a.toLowerCase().includes(lowered))
+			.slice(0, 8);
+	};
+
+	onMount(async () => {
+		await Promise.all([loadFile(), loadAutocompleteSources()]);
+	});
+</script>
+
+<div class="recurring-rules-editor">
+	<div class="header-row">
+		<h4>Rules</h4>
+		<div class="actions">
+			<button on:click={addRule}>+ Add rule</button>
+			<button on:click={validate} title="Parse the file and report any malformed lines">Validate</button>
+			<button on:click={loadFile} title="Discard local edits and reload from disk">Reload</button>
+			<button on:click={save} disabled={!dirty} class="cta" title="Write changes to {resolvedPath}">Save</button>
+		</div>
+	</div>
+
+	{#if resolvedPath}
+		<div class="path-line">File: <code>{resolvedPath}</code></div>
+	{/if}
+	{#if loading}
+		<p class="muted">Loading…</p>
+	{/if}
+	{#if saveError}
+		<p class="error-msg">{saveError}</p>
+	{/if}
+
+	{#if !loading && rules.length === 0}
+		<p class="muted">No rules yet — click <strong>+ Add rule</strong> to start.</p>
+	{/if}
+
+	<div class="rule-cards">
+		{#each rules as rule (rule._localId)}
+			{@const valid = ruleIsValid(rule)}
+			{@const preview = previewOccurrences(rule)}
+			<div class="rule-card" class:invalid={!valid.ok}>
+				<div class="card-row title-row">
+					<input
+						class="nickname"
+						type="text"
+						placeholder="nickname"
+						bind:value={rule.nickname}
+						on:input={markDirty}
+					/>
+					<select
+						class="cadence"
+						bind:value={rule.cadence}
+						on:change={markDirty}
+					>
+						{#each CADENCES as c}
+							<option value={c}>{c}</option>
+						{/each}
+					</select>
+					<button
+						class="ghost"
+						on:click={() => openFileAtLine(rule.sourceLine)}
+						disabled={!rule.sourceLine}
+						title={rule.sourceLine ? `Open ${resolvedPath} at line ${rule.sourceLine}` : 'New rule — save first to enable jump'}
+					>↗ Open</button>
+					<button class="danger ghost" on:click={() => removeRule(rule._localId)} title="Remove rule">✕</button>
+				</div>
+
+				<div class="card-row">
+					<label class="field">
+						<span>Destination</span>
+						<input
+							type="text"
+							list="recurring-accounts-{rule._localId}"
+							placeholder={rule.amount >= 0 && rule.fundingAccount.startsWith('Income') ? 'Assets:Bank…' : 'Expenses:…'}
+							bind:value={rule.expenseAccount}
+							on:input={markDirty}
+						/>
+						<datalist id="recurring-accounts-{rule._localId}">
+							{#each filteredAccountSuggest(rule.expenseAccount) as acc}
+								<option value={acc} />
+							{/each}
+						</datalist>
+					</label>
+
+					<label class="field">
+						<span>Funding</span>
+						<input
+							type="text"
+							list="recurring-funding-{rule._localId}"
+							placeholder="Assets:Banking:…"
+							bind:value={rule.fundingAccount}
+							on:input={markDirty}
+						/>
+						<datalist id="recurring-funding-{rule._localId}">
+							{#each filteredAccountSuggest(rule.fundingAccount) as acc}
+								<option value={acc} />
+							{/each}
+						</datalist>
+					</label>
+				</div>
+
+				<div class="card-row">
+					<label class="field amount">
+						<span>Amount</span>
+						<input
+							type="number"
+							step="0.01"
+							bind:value={rule.amount}
+							on:input={markDirty}
+						/>
+					</label>
+
+					<label class="field currency">
+						<span>Currency</span>
+						<input
+							type="text"
+							list="recurring-currencies-{rule._localId}"
+							placeholder="USD"
+							bind:value={rule.currency}
+							on:input={markDirty}
+						/>
+						<datalist id="recurring-currencies-{rule._localId}">
+							{#each currencies as c}
+								<option value={c} />
+							{/each}
+						</datalist>
+					</label>
+
+					<label class="field date">
+						<span>Start date</span>
+						<input
+							type="date"
+							bind:value={rule.startDate}
+							on:input={markDirty}
+						/>
+					</label>
+				</div>
+
+				{#if !valid.ok}
+					<div class="card-row issue">⚠ {valid.reason}</div>
+				{:else if preview.length > 0}
+					<div class="card-row preview" title="Next up to 3 occurrences within a year of today">
+						Next:
+						{#each preview as p, i}
+							<span class="pill">{p}</span>{#if i < preview.length - 1}{' '}{/if}
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.recurring-rules-editor {
+		margin-top: 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.header-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+	.header-row h4 {
+		margin: 0;
+	}
+	.header-row .actions {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+	.header-row .actions button {
+		padding: 4px 10px;
+		border-radius: var(--radius-s);
+	}
+	.cta {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+	.cta[disabled] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.path-line {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+
+	.muted { color: var(--text-muted); }
+
+	.error-msg {
+		color: var(--color-red);
+		font-size: var(--font-ui-small);
+	}
+
+	.rule-cards {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.rule-card {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		padding: 10px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		background: var(--background-secondary);
+	}
+	.rule-card.invalid {
+		border-color: var(--color-red);
+	}
+
+	.card-row {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	.title-row .nickname {
+		flex: 1 1 auto;
+		min-width: 140px;
+		font-weight: 600;
+	}
+	.title-row .cadence {
+		flex: 0 0 auto;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		flex: 1 1 200px;
+	}
+	.field span {
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
+	}
+	.field input,
+	.field select {
+		width: 100%;
+	}
+	.field.amount,
+	.field.currency,
+	.field.date {
+		flex: 0 0 auto;
+		min-width: 110px;
+	}
+	.field.amount input { width: 110px; }
+
+	.ghost {
+		background: transparent;
+	}
+	.danger {
+		color: var(--color-red);
+	}
+
+	.issue {
+		color: var(--color-red);
+		font-size: var(--font-ui-small);
+	}
+
+	.preview {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+	.pill {
+		display: inline-block;
+		padding: 1px 8px;
+		border-radius: 999px;
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		font-variant-numeric: tabular-nums;
+		margin-right: 4px;
+	}
+</style>

--- a/src/ui/partials/settings/RecurringRulesEditor.svelte
+++ b/src/ui/partials/settings/RecurringRulesEditor.svelte
@@ -10,7 +10,7 @@
 		type RecurringRule,
 		type RecurringCadence,
 	} from '../../../services/recurring.service';
-	import { getOpenAccounts } from '../../../utils/accounts';
+	import { getOpenAccounts, getCommodities } from '../../../utils/accounts';
 	import { getAllCurrenciesQuery } from '../../../queries/index';
 	import { parse as parseCsv } from 'csv-parse/sync';
 	import { Logger } from '../../../utils/logger';
@@ -70,18 +70,38 @@
 
 	async function loadAutocompleteSources() {
 		try {
-			const [accs, csv] = await Promise.all([
+			// Two sources, unioned: `#commodities` covers every declared
+			// commodity (canonical list); `distinct(currency)` from postings
+			// catches anything actually transacted.
+			const [accs, declaredCommodities, postingsCsv] = await Promise.all([
 				getOpenAccounts(plugin),
+				getCommodities(plugin).catch(() => [] as Array<{ name: string }>),
 				plugin.runQuery(getAllCurrenciesQuery()).catch(() => ''),
 			]);
 			accounts = accs ?? [];
-			if (csv) {
-				const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
-				const fetched = rows.map((r: any) => r['currency_']).filter(Boolean) as string[];
-				if (fetched.length > 0) currencies = Array.from(new Set(fetched));
+
+			const merged = new Set<string>();
+			for (const c of declaredCommodities ?? []) {
+				if (c?.name) merged.add(c.name);
+			}
+			if (postingsCsv) {
+				const rows = parseCsv(postingsCsv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+				for (const r of rows) {
+					const code = (r['currency_'] ?? '').trim();
+					if (code) merged.add(code);
+				}
 			}
 			const op = plugin.settings.operatingCurrency;
-			if (op && !currencies.includes(op)) currencies.unshift(op);
+			if (op) merged.add(op);
+
+			const sorted = Array.from(merged).sort((a, b) => {
+				if (op) {
+					if (a === op) return -1;
+					if (b === op) return 1;
+				}
+				return a.localeCompare(b);
+			});
+			if (sorted.length > 0) currencies = sorted;
 		} catch (e) {
 			Logger.log('[RecurringRulesEditor] failed to load autocomplete sources', e);
 		}

--- a/src/ui/views/dashboard/unified-dashboard-view.ts
+++ b/src/ui/views/dashboard/unified-dashboard-view.ts
@@ -105,6 +105,13 @@ export class UnifiedDashboardView extends ItemView {
 		this.transactionController.handleFilterChange({}); // Load initial transactions
 		this.balanceSheetController.loadData();
 		this.incomeStatementController.loadData();
+
+		// --- Listen for cross-component refresh signals ---
+		this.registerEvent(
+			(this.app.workspace as any).on('beancount:recurring-rules-updated', () => {
+				this.recurringController.refresh().catch(() => { /* widget may not yet be wired */ });
+			})
+		);
 	}
 
 	async onClose() {


### PR DESCRIPTION
## Summary

Follow-up to #125 (read+render MVP) — makes the recurring rules authorable from inside the plugin's settings tab without leaving Obsidian.

Adds a `RecurringRulesEditor.svelte` component embedded in **Settings → General → Recurring Transactions** that lists every parsed rule as an editable card and offers full CRUD plus quality-of-life affordances.

## Features

- **Per-rule card**: nickname, cadence (dropdown), destination + funding accounts (datalist autocomplete sourced from `getOpenAccounts`), amount, currency (autocomplete from `getAllCurrenciesQuery`), start-date (HTML date input).
- **Inline preview** beneath each card: next up-to-3 occurrences within a one-year window, computed via `occurrencesInWindow`.
- **Per-rule "↗ Open"** button: opens the source file in a new leaf and scrolls the cursor to the rule's source line.
- **Add / Remove** rule buttons.
- **Validate** button: surfaces malformed lines via `validateRecurringFile()` (file shape, unknown cadence, unparseable amount), with a 5-issue truncation + count.
- **Reload** button: discards local edits and re-reads disk.
- **Save** button: writes back via `applyRecurringEdits` — a surgical rewrite that touches only the directive lines, leaving comments and blank lines exactly where the user put them.
- **Browse** extra-button on the file-path setting: opens a `FuzzySuggestModal` listing every `.beancount` file in the vault.
- **Workspace event** `beancount:recurring-rules-updated` dispatched on save; the unified dashboard view listens and refreshes its `RecurringController` so the widget picks up the change without a manual reload.

## Two new pure helpers in `recurring.service.ts`

- `formatRecurringRule(rule)`: emits a directive line that round-trips with `parseRecurringFile`.
- `applyRecurringEdits(content, rules)`: in-place rewrite using the `sourceLine` field on each parsed rule. New rules append after the last existing line with one blank for breathing room; deleted rules splice out cleanly. Round-trips comments byte-for-byte for the lines that aren't directives.
- `validateRecurringFile(content)`: returns shape / cadence / amount diagnostics for any line that contains `"recurring"` but fails to parse.

## Why surgical writes instead of full re-emit

The file is a Beancount artifact and users will hand-edit it. Re-emitting would obliterate section comments and trailing notes. Tracking `sourceLine` lets us keep the on-disk shape intact while updating exactly the rules the UI changed.

## Test plan

- [x] 6 real rules render with editable fields, autocomplete works.
- [x] Cadence dropdown shows all 7 cadences.
- [x] Inline preview shows next 3 dates per rule (e.g. May 28, Jun 28, Jul 28 for monthly).
- [x] "↗ Open" jumps to the correct line in `recurring.beancount`.
- [x] Validate shows "No issues found" for the user's clean file.
- [x] Save is disabled when clean, enables on edit.
- [x] No console errors on plugin reload.