### PR TITLE
feat(liabilities): add Liabilities & Receivables dashboard tab

### DIFF
--- a/src/controllers/LiabilitiesController.ts
+++ b/src/controllers/LiabilitiesController.ts
@@ -1,0 +1,160 @@
+// src/controllers/LiabilitiesController.ts
+//
+// Reads `open` directives from the structured accounts file, parses
+// out loan-shaped metadata via liabilities.service, joins each
+// account with its current balance pulled from BQL, and exposes a
+// reactive Svelte store for the Liabilities & Receivables tab.
+
+import { writable, type Writable, get } from 'svelte/store';
+import type BeancountPlugin from '../main';
+import { parse as parseCsv } from 'csv-parse/sync';
+import * as queries from '../queries/index';
+import {
+    parseLoanAccounts,
+    type LoanAccount,
+} from '../services/liabilities.service';
+import { Logger } from '../utils/logger';
+
+export interface LoanRow extends LoanAccount {
+    /** Live balance from the ledger, in the account's currency. Null if no movements yet. */
+    currentBalance: number | null;
+    /** Display string for the live balance (e.g. "-12,500.00 UYU"). */
+    currentBalanceDisplay: string;
+}
+
+export interface LiabilitiesState {
+    isLoading: boolean;
+    error: string | null;
+    liabilities: LoanRow[];
+    receivables: LoanRow[];
+    /** Vault-relative path of the accounts file that was read. */
+    sourcePath: string;
+    /** Sum of liability balances in the operating currency, for a header KPI. */
+    totalLiabilities: number | null;
+    /** Sum of receivable balances in the operating currency, for a header KPI. */
+    totalReceivables: number | null;
+    /** Reporting currency. */
+    currency: string;
+}
+
+/**
+ * Resolve the accounts file path. We default to
+ * `<structuredFolder>/accounts.beancount` since the plugin's
+ * structured layout assumes that filename.
+ */
+function resolveAccountsPath(plugin: BeancountPlugin): string {
+    const folder = plugin.settings.structuredFolderName?.trim() || 'Finances';
+    return `${folder}/accounts.beancount`;
+}
+
+function parseBalanceCell(raw: string): { amount: number | null; currency: string | null } {
+    // BQL `sum(position)` returns a string like "12500.00 UYU" or
+    // "-200.00 UYU, 5.00 USD" for multi-currency positions. We split
+    // on the first comma and parse the first component.
+    if (!raw) return { amount: null, currency: null };
+    const first = raw.split(',')[0].trim();
+    const parts = first.split(/\s+/);
+    if (parts.length < 2) return { amount: null, currency: null };
+    const amount = parseFloat(parts[0].replace(/,/g, ''));
+    const currency = parts[1];
+    return { amount: isFinite(amount) ? amount : null, currency: currency || null };
+}
+
+function formatBalance(amount: number | null, currency: string | null): string {
+    if (amount === null) return '—';
+    const ccy = currency || '';
+    return `${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${ccy}`.trim();
+}
+
+export class LiabilitiesController {
+    private plugin: BeancountPlugin;
+    public state: Writable<LiabilitiesState>;
+
+    constructor(plugin: BeancountPlugin) {
+        this.plugin = plugin;
+        this.state = writable({
+            isLoading: true,
+            error: null,
+            liabilities: [],
+            receivables: [],
+            sourcePath: '',
+            totalLiabilities: null,
+            totalReceivables: null,
+            currency: plugin.settings.operatingCurrency || 'USD',
+        });
+    }
+
+    async loadData(): Promise<void> {
+        this.state.update(s => ({ ...s, isLoading: true, error: null }));
+        const sourcePath = resolveAccountsPath(this.plugin);
+
+        try {
+            // Parse account file metadata. If the file is missing the tab
+            // simply renders empty — this is a soft-fail situation, not an error.
+            const adapter = this.plugin.app.vault.adapter;
+            let accounts: LoanAccount[] = [];
+            if (await adapter.exists(sourcePath)) {
+                const content = await adapter.read(sourcePath);
+                accounts = parseLoanAccounts(content);
+            }
+
+            // Pull live balances. Treat BQL failure as soft: we still show metadata.
+            let balanceMap = new Map<string, { amount: number | null; currency: string | null }>();
+            try {
+                const csv = await this.plugin.runQuery(queries.getLoanBalancesQuery());
+                const cleaned = csv.replace(/\r/g, '').trim();
+                const records: string[][] = parseCsv(cleaned, { columns: false, skip_empty_lines: true, relax_column_count: true });
+                const firstRowIsHeader = records[0]?.[0]?.toLowerCase().includes('account');
+                const rows = firstRowIsHeader ? records.slice(1) : records;
+                for (const row of rows) {
+                    if (row.length < 2) continue;
+                    balanceMap.set(row[0], parseBalanceCell(row[1]));
+                }
+            } catch (e) {
+                Logger.log('[LiabilitiesController] balance query failed (continuing with metadata only):', e);
+            }
+
+            const enriched: LoanRow[] = accounts.map(acc => {
+                const bal = balanceMap.get(acc.account);
+                const amount = bal?.amount ?? null;
+                const currency = bal?.currency ?? acc.currency;
+                return {
+                    ...acc,
+                    currentBalance: amount,
+                    currentBalanceDisplay: formatBalance(amount, currency),
+                };
+            });
+
+            const liabilities = enriched.filter(r => r.role === 'liability');
+            const receivables = enriched.filter(r => r.role === 'receivable');
+
+            // Header KPIs: sum balances *in their declared currency* — we're
+            // not converting here (the Overview tab already shows the
+            // operating-currency aggregate via the existing query).
+            const sumByCurrency = (rows: LoanRow[]): number | null => {
+                const present = rows.filter(r => r.currentBalance !== null);
+                if (present.length === 0) return null;
+                return present.reduce((acc, r) => acc + (r.currentBalance ?? 0), 0);
+            };
+
+            this.state.set({
+                isLoading: false,
+                error: null,
+                liabilities,
+                receivables,
+                sourcePath,
+                totalLiabilities: sumByCurrency(liabilities),
+                totalReceivables: sumByCurrency(receivables),
+                currency: this.plugin.settings.operatingCurrency || 'USD',
+            });
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            Logger.log('[LiabilitiesController] loadData failed:', e);
+            this.state.update(s => ({ ...s, isLoading: false, error: msg }));
+        }
+    }
+
+    async refresh(): Promise<void> {
+        await this.loadData();
+    }
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -205,3 +205,13 @@ export function getAllPricesQuery(limit: number = 100): string {
 export function getAllCurrenciesQuery(): string {
 	return `SELECT distinct(currency) AS currency_`;
 }
+
+/**
+ * Current balance per account in the Liabilities and Assets:Receivables
+ * sub-trees, returned as a position (with currency). Used by the
+ * Liabilities & Receivables tab to show the live balance alongside
+ * the contractual metadata read from the accounts file.
+ */
+export function getLoanBalancesQuery(): string {
+	return `SELECT account, sum(position) WHERE account ~ '^(Liabilities|Assets:Receivables)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
+}

--- a/src/services/liabilities.service.ts
+++ b/src/services/liabilities.service.ts
@@ -1,0 +1,218 @@
+// src/services/liabilities.service.ts
+//
+// Parses Beancount `open` directives plus their indented metadata to
+// surface accounts that represent loans, credit lines, mortgages or
+// receivables on a dedicated dashboard tab. Pure functions only — no
+// I/O — so the parser is unit-testable.
+//
+// Recognised metadata keys (all optional; account is included if it
+// has *any* of them OR if its name starts with "Liabilities:" or
+// "Assets:Receivables:"):
+//
+//   loan-type:        free-form string ("credit-card", "mortgage",
+//                     "personal-loan", "receivable", etc.)
+//   principal:        original amount (number, no currency suffix —
+//                     the account's open-currency is used)
+//   interest-rate:    annual percentage as a number (e.g. 29.5)
+//   monthly-payment:  number (no currency suffix)
+//   due-day:          day of month (1–31) when payment is due
+//   counterparty:     human label ("Banco Santander", "Maria Esther")
+//
+// Source format example:
+//
+//   2026-01-01 open Liabilities:Credit:Visa  USD
+//     loan-type: "credit-card"
+//     principal: 50000
+//     interest-rate: 29.5
+//     monthly-payment: 5000
+//     due-day: 10
+//     counterparty: "Banco Santander"
+//
+//   2026-02-01 open Assets:Receivables:Maria  UYU
+//     loan-type: "receivable"
+//     principal: 12000
+//     monthly-payment: 1000
+//     due-day: 15
+
+export type LoanRole = 'liability' | 'receivable';
+
+export interface LoanAccount {
+    /** Full account path (e.g. "Liabilities:Credit:Visa"). */
+    account: string;
+    /** Currency declared on the open directive (first declared currency wins). */
+    currency: string;
+    /** ISO open-date. */
+    openDate: string;
+    /** Whether this account represents money the user owes (liability) or is owed (receivable). */
+    role: LoanRole;
+    /** Free-form loan classification (credit-card, mortgage, personal-loan, receivable, …). */
+    loanType: string | null;
+    /** Counterparty label (bank, lender, friend, …). */
+    counterparty: string | null;
+    /** Original / face amount of the loan. */
+    principal: number | null;
+    /** Annual interest rate as a number (e.g. 29.5 for 29.5%). */
+    interestRate: number | null;
+    /** Monthly payment amount in the account currency. */
+    monthlyPayment: number | null;
+    /** Day-of-month the payment is due (1–31). */
+    dueDay: number | null;
+    /** 1-based source line number of the open directive (for "open file at rule" jumps). */
+    sourceLine?: number;
+}
+
+const OPEN_DIRECTIVE = /^(\d{4}-\d{2}-\d{2})\s+open\s+([A-Z][A-Za-z0-9:_-]*)\s*([A-Z][A-Z0-9'._-]*)?(?:\s+"[^"]*")?\s*$/;
+const META_LINE = /^\s+([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$/;
+
+/**
+ * Strip Beancount string quoting from a metadata value. Numeric and
+ * bare values pass through unchanged. Returns `null` for empty.
+ */
+function unquote(raw: string): string {
+    const t = raw.trim();
+    if (!t) return '';
+    if (t.startsWith('"') && t.endsWith('"') && t.length >= 2) {
+        return t.slice(1, -1);
+    }
+    return t;
+}
+
+function toNumber(raw: string): number | null {
+    const t = unquote(raw).trim();
+    if (!t) return null;
+    const n = parseFloat(t);
+    return isFinite(n) ? n : null;
+}
+
+function inferRole(account: string, loanType: string | null): LoanRole {
+    if (account.startsWith('Liabilities:') || account === 'Liabilities') return 'liability';
+    if (account.startsWith('Assets:Receivables') || /^Receivables(:|$)/.test(account)) return 'receivable';
+    if ((loanType || '').toLowerCase().includes('receivable')) return 'receivable';
+    return 'liability';
+}
+
+/**
+ * Parse the contents of an accounts file (typically accounts.beancount)
+ * for `open` directives whose metadata identifies them as loan-like.
+ * Lines that don't match the directive shape are silently ignored.
+ */
+export function parseLoanAccounts(content: string): LoanAccount[] {
+    const out: LoanAccount[] = [];
+    const lines = content.split(/\r?\n/);
+
+    let pending: { startLine: number; openDate: string; account: string; currency: string; meta: Record<string, string> } | null = null;
+
+    const flush = () => {
+        if (!pending) return;
+        const { account, openDate, currency, meta, startLine } = pending;
+        const loanType = meta['loan-type'] ? unquote(meta['loan-type']) : null;
+        const isLoanShaped =
+            loanType !== null ||
+            'principal' in meta ||
+            'monthly-payment' in meta ||
+            'interest-rate' in meta ||
+            'due-day' in meta ||
+            account.startsWith('Liabilities:') ||
+            account.startsWith('Assets:Receivables');
+        if (isLoanShaped) {
+            const dueDay = meta['due-day'] ? toNumber(meta['due-day']) : null;
+            out.push({
+                account,
+                currency,
+                openDate,
+                role: inferRole(account, loanType),
+                loanType,
+                counterparty: meta['counterparty'] ? unquote(meta['counterparty']) : null,
+                principal: meta['principal'] ? toNumber(meta['principal']) : null,
+                interestRate: meta['interest-rate'] ? toNumber(meta['interest-rate']) : null,
+                monthlyPayment: meta['monthly-payment'] ? toNumber(meta['monthly-payment']) : null,
+                dueDay: dueDay !== null && dueDay >= 1 && dueDay <= 31 ? Math.round(dueDay) : null,
+                sourceLine: startLine,
+            });
+        }
+        pending = null;
+    };
+
+    for (let i = 0; i < lines.length; i++) {
+        const raw = lines[i];
+        const trimmed = raw.trim();
+
+        if (!trimmed || trimmed.startsWith(';')) {
+            // blank / comment line outside an open block resets pending only at the boundary
+            // (we still allow blank lines after metadata to terminate the block).
+            if (pending && !trimmed) flush();
+            continue;
+        }
+
+        const openMatch = OPEN_DIRECTIVE.exec(raw);
+        if (openMatch) {
+            // Flush the previous block if any, then start a new pending one.
+            flush();
+            const [, openDate, account, currency] = openMatch;
+            pending = {
+                startLine: i + 1,
+                openDate,
+                account,
+                currency: currency || '',
+                meta: {},
+            };
+            continue;
+        }
+
+        if (pending) {
+            const metaMatch = META_LINE.exec(raw);
+            if (metaMatch) {
+                pending.meta[metaMatch[1]] = metaMatch[2];
+                continue;
+            }
+            // Non-metadata, non-open content: terminate the block.
+            flush();
+        }
+    }
+    flush();
+    return out;
+}
+
+/**
+ * Compute the next due date (YYYY-MM-DD) for a loan account, given a
+ * reference date. If `dueDay` falls today, today is returned. If it
+ * already passed this month, the same day next month is used (clamped
+ * to the month-end for short months).
+ */
+export function nextDueDate(dueDay: number | null, today: string = new Date().toISOString().slice(0, 10)): string | null {
+    if (dueDay === null || !isFinite(dueDay)) return null;
+    const [y, m, d] = today.split('-').map(Number);
+    const clamp = (year: number, month: number, day: number): string => {
+        const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+        const safe = Math.min(Math.max(1, Math.round(day)), lastDay);
+        return `${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${safe.toString().padStart(2, '0')}`;
+    };
+    if (d <= dueDay) return clamp(y, m, dueDay);
+    // Otherwise, roll forward one month.
+    const nextYear = m === 12 ? y + 1 : y;
+    const nextMonth = m === 12 ? 1 : m + 1;
+    return clamp(nextYear, nextMonth, dueDay);
+}
+
+/**
+ * Days between two ISO dates (b - a). Negative means a is after b.
+ */
+export function daysBetween(a: string, b: string): number {
+    const da = new Date(a + 'T00:00:00Z').getTime();
+    const db = new Date(b + 'T00:00:00Z').getTime();
+    return Math.round((db - da) / 86400000);
+}
+
+/**
+ * Compute the user-facing payoff fraction (0..1) given a balance and
+ * a principal. For liabilities the balance is typically negative
+ * (Beancount credit) and shrinks toward zero as it's paid off; for
+ * receivables it's positive and shrinks the same way. We normalise
+ * by absolute values so the fraction is meaningful in both cases.
+ * Returns `null` if principal is missing or zero.
+ */
+export function payoffFraction(currentBalance: number | null, principal: number | null): number | null {
+    if (principal === null || principal === 0 || currentBalance === null) return null;
+    const remaining = Math.abs(currentBalance) / Math.abs(principal);
+    return Math.max(0, Math.min(1, 1 - remaining));
+}

--- a/src/ui/partials/dashboard/LiabilitiesTab.svelte
+++ b/src/ui/partials/dashboard/LiabilitiesTab.svelte
@@ -1,0 +1,378 @@
+<!-- src/ui/partials/dashboard/LiabilitiesTab.svelte -->
+<script lang="ts">
+	import { writable, type Writable } from 'svelte/store';
+	import { MarkdownView } from 'obsidian';
+	import type { LiabilitiesController, LiabilitiesState, LoanRow } from '../../../controllers/LiabilitiesController';
+	import { nextDueDate, daysBetween, payoffFraction } from '../../../services/liabilities.service';
+
+	export let controller: LiabilitiesController;
+	export let plugin: any = null;
+
+	const placeholderState: Writable<LiabilitiesState> = writable({
+		isLoading: true, error: null, liabilities: [], receivables: [], sourcePath: '',
+		totalLiabilities: null, totalReceivables: null, currency: 'USD',
+	});
+
+	$: stateStore = controller ? controller.state : placeholderState;
+	$: state = $stateStore;
+
+	function formatNumber(n: number | null, opts: { signed?: boolean } = {}): string {
+		if (n === null) return '—';
+		const v = n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+		return opts.signed && n > 0 ? `+${v}` : v;
+	}
+
+	function formatPercent(n: number | null): string {
+		if (n === null) return '—';
+		return `${n.toFixed(2)}%`;
+	}
+
+	function todayIso(): string {
+		return new Date().toISOString().slice(0, 10);
+	}
+
+	function relativeDue(dueDay: number | null): string {
+		if (dueDay === null) return '';
+		const next = nextDueDate(dueDay, todayIso());
+		if (!next) return '';
+		const days = daysBetween(todayIso(), next);
+		if (days === 0) return 'today';
+		if (days === 1) return 'tomorrow';
+		if (days < 0) return `${Math.abs(days)}d ago`;
+		return `in ${days}d`;
+	}
+
+	function nextDueLabel(dueDay: number | null): string {
+		const next = nextDueDate(dueDay, todayIso());
+		return next ?? '—';
+	}
+
+	function payoffPct(row: LoanRow): number | null {
+		const f = payoffFraction(row.currentBalance, row.principal);
+		return f === null ? null : f * 100;
+	}
+
+	async function openSource(row: LoanRow) {
+		if (!plugin || !row.sourceLine) return;
+		try {
+			const file = plugin.app.vault.getAbstractFileByPath(state.sourcePath);
+			if (!file) return;
+			const leaf = plugin.app.workspace.getLeaf(true);
+			await leaf.openFile(file as any);
+			const view = leaf.view;
+			if (view instanceof MarkdownView && view.editor) {
+				const line = Math.max(0, (row.sourceLine ?? 1) - 1);
+				view.editor.setCursor({ line, ch: 0 });
+				view.editor.scrollIntoView({ from: { line, ch: 0 }, to: { line, ch: 0 } }, true);
+			}
+		} catch (_) {
+			/* defensive */
+		}
+	}
+
+	function handleRefresh() {
+		if (controller) controller.refresh();
+	}
+</script>
+
+<div class="liabilities-tab">
+	<div class="header">
+		<h3>Liabilities &amp; Receivables</h3>
+		<button class="refresh-button" on:click={handleRefresh} disabled={state.isLoading} title="Reload accounts file and balances">
+			{#if state.isLoading}
+				Refreshing…
+			{:else}
+				Refresh
+			{/if}
+		</button>
+	</div>
+
+	{#if state.error}
+		<p class="error-msg">Error: {state.error}</p>
+	{/if}
+
+	{#if state.isLoading && state.liabilities.length === 0 && state.receivables.length === 0}
+		<p class="muted">Loading…</p>
+	{:else}
+		<div class="kpis">
+			<div class="kpi-card">
+				<div class="kpi-label">Total liabilities</div>
+				<div class="kpi-value">{formatNumber(state.totalLiabilities)}</div>
+				<div class="kpi-foot">Sum of current balances</div>
+			</div>
+			<div class="kpi-card">
+				<div class="kpi-label">Total receivables</div>
+				<div class="kpi-value">{formatNumber(state.totalReceivables)}</div>
+				<div class="kpi-foot">Sum of current balances</div>
+			</div>
+		</div>
+
+		{#if state.liabilities.length === 0 && state.receivables.length === 0}
+			<div class="loan-empty-state">
+				<p>No loan-shaped accounts found.</p>
+				<p class="muted">
+					Add metadata to <code>open</code> directives in
+					<code>{state.sourcePath || 'accounts.beancount'}</code> like:
+				</p>
+				<pre><code>2026-01-01 open Liabilities:Credit:Visa  USD
+  loan-type: "credit-card"
+  principal: 50000
+  interest-rate: 29.5
+  monthly-payment: 5000
+  due-day: 10
+  counterparty: "Banco Santander"</code></pre>
+			</div>
+		{/if}
+
+		{#each [
+			{ title: 'Liabilities', rows: state.liabilities, accentClass: 'role-liability' },
+			{ title: 'Receivables', rows: state.receivables, accentClass: 'role-receivable' },
+		] as section}
+			{#if section.rows.length > 0}
+				<section class={section.accentClass}>
+					<h4>{section.title}</h4>
+					<div class="loan-grid">
+						{#each section.rows as row (row.account)}
+							{@const pct = payoffPct(row)}
+							<article class="loan-card">
+								<header class="loan-card-header">
+									<div class="account">
+										<span class="account-name">{row.account}</span>
+										{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
+									</div>
+									{#if plugin && row.sourceLine}
+										<button class="ghost" on:click={() => openSource(row)} title="Open accounts file at line {row.sourceLine}">↗</button>
+									{/if}
+								</header>
+
+								<div class="balance-block">
+									<span class="balance-label">Balance</span>
+									<span class="balance">{row.currentBalanceDisplay}</span>
+								</div>
+
+								<dl class="meta">
+									{#if row.counterparty}
+										<dt>Counterparty</dt><dd>{row.counterparty}</dd>
+									{/if}
+									{#if row.principal !== null}
+										<dt>Principal</dt><dd>{formatNumber(row.principal)} {row.currency}</dd>
+									{/if}
+									{#if row.interestRate !== null}
+										<dt>Interest</dt><dd>{formatPercent(row.interestRate)} APR</dd>
+									{/if}
+									{#if row.monthlyPayment !== null}
+										<dt>Monthly</dt><dd>{formatNumber(row.monthlyPayment)} {row.currency}</dd>
+									{/if}
+									{#if row.dueDay !== null}
+										<dt>Next due</dt>
+										<dd>
+											{nextDueLabel(row.dueDay)}
+											<span class="muted small">({relativeDue(row.dueDay)})</span>
+										</dd>
+									{/if}
+								</dl>
+
+								{#if pct !== null}
+									<div class="payoff" title="{pct.toFixed(1)}% paid off vs. principal">
+										<div class="payoff-bar"><div class="payoff-fill" style="width: {pct}%"></div></div>
+										<span class="payoff-label">{pct.toFixed(0)}% paid off</span>
+									</div>
+								{/if}
+							</article>
+						{/each}
+					</div>
+				</section>
+			{/if}
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.liabilities-tab {
+		padding: var(--size-4-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+	}
+
+	.header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding-bottom: var(--size-4-2);
+		border-bottom: 1px solid var(--background-modifier-border);
+	}
+
+	.refresh-button {
+		padding: 4px 10px;
+		border-radius: var(--radius-s);
+	}
+
+	.error-msg { color: var(--color-red); }
+	.muted { color: var(--text-muted); }
+	.small { font-size: var(--font-ui-smaller); }
+
+	.kpis {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: var(--size-4-3);
+	}
+	.kpi-card {
+		padding: var(--size-4-4);
+		background: var(--background-secondary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+	}
+	.kpi-label {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+		margin-bottom: var(--size-4-2);
+	}
+	.kpi-value {
+		font-size: 1.6em;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+	.kpi-foot {
+		margin-top: var(--size-4-1);
+		font-size: var(--font-ui-smaller);
+		color: var(--text-faint);
+	}
+
+	.loan-empty-state {
+		padding: var(--size-4-4);
+		border: 1px dashed var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		background: var(--background-secondary);
+	}
+	.loan-empty-state pre {
+		background: var(--background-primary);
+		padding: var(--size-4-3);
+		border-radius: var(--radius-s);
+		overflow-x: auto;
+	}
+
+	section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-2);
+	}
+
+	.loan-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: var(--size-4-3);
+	}
+
+	.loan-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-2);
+		padding: var(--size-4-3);
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		border-top: 3px solid var(--background-modifier-border);
+	}
+	.role-liability .loan-card {
+		border-top-color: var(--color-red);
+	}
+	.role-receivable .loan-card {
+		border-top-color: var(--color-green);
+	}
+
+	.loan-card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 8px;
+	}
+	.account {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.account-name {
+		font-weight: 600;
+		font-size: var(--font-ui-small);
+		word-break: break-word;
+	}
+	.badge {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: 999px;
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		background: var(--background-modifier-hover);
+		color: var(--text-muted);
+		width: fit-content;
+	}
+
+	.balance-block {
+		display: flex;
+		flex-direction: column;
+	}
+	.balance-label {
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
+	}
+	.balance {
+		font-size: 1.4em;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+
+	dl.meta {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		column-gap: var(--size-4-3);
+		row-gap: 4px;
+		margin: 0;
+		font-size: var(--font-ui-small);
+	}
+	dl.meta dt {
+		color: var(--text-muted);
+	}
+	dl.meta dd {
+		margin: 0;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.payoff {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.payoff-bar {
+		flex: 1;
+		height: 6px;
+		background: var(--background-modifier-border);
+		border-radius: 999px;
+		overflow: hidden;
+	}
+	.payoff-fill {
+		height: 100%;
+		background: var(--interactive-accent);
+		transition: width 0.3s ease;
+	}
+	.payoff-label {
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ghost {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 4px 6px;
+		border-radius: var(--radius-s);
+	}
+	.ghost:hover {
+		color: var(--text-normal);
+		background: var(--background-modifier-hover);
+	}
+</style>

--- a/src/ui/views/dashboard/UnifiedDashboardView.svelte
+++ b/src/ui/views/dashboard/UnifiedDashboardView.svelte
@@ -8,6 +8,7 @@
     import CommoditiesTab from '../../partials/dashboard/CommoditiesTab.svelte';
     import JournalTab from '../../partials/dashboard/JournalTab.svelte';
     import IncomeStatementTab from '../../partials/dashboard/IncomeStatementTab.svelte';
+    import LiabilitiesTab from '../../partials/dashboard/LiabilitiesTab.svelte';
 
     // Types
     import type { OverviewController } from '../../../controllers/OverviewController';
@@ -16,6 +17,7 @@
     import type { CommoditiesController } from '../../../controllers/CommoditiesController';
     import type { IncomeStatementController } from '../../../controllers/IncomeStatementController';
     import type { RecurringController } from '../../../controllers/RecurringController';
+    import type { LiabilitiesController } from '../../../controllers/LiabilitiesController';
 
     // Props
     export let overviewController: OverviewController;
@@ -24,6 +26,7 @@
     export let commoditiesController: CommoditiesController;
     export let incomeStatementController: IncomeStatementController;
     export let recurringController: RecurringController | null = null;
+    export let liabilitiesController: LiabilitiesController | null = null;
     export let journalStore: any;
     export let plugin: any = null; // Add plugin prop
 
@@ -35,6 +38,7 @@
         { id: 'journal', label: 'Journal' },
         { id: 'balancesheet', label: 'Accounts & Balances' },
         { id: 'incomestatement', label: 'Income Statement' },
+        { id: 'liabilities', label: 'Liabilities & Receivables' },
         { id: 'commodities', label: 'Commodities' }
     ];
 </script>
@@ -69,6 +73,10 @@
             <BalanceSheetTab controller={balanceSheetController} />
         {:else if activeTab === 'incomestatement'}
             <IncomeStatementTab controller={incomeStatementController} />
+        {:else if activeTab === 'liabilities'}
+            {#if liabilitiesController}
+                <LiabilitiesTab controller={liabilitiesController} {plugin} />
+            {/if}
         {:else if activeTab === 'commodities'}
             <CommoditiesTab controller={commoditiesController} {plugin} on:openCommodity on:addCommodity />
         {/if}

--- a/src/ui/views/dashboard/unified-dashboard-view.ts
+++ b/src/ui/views/dashboard/unified-dashboard-view.ts
@@ -13,6 +13,7 @@ import { BalanceSheetController } from '../../../controllers/BalanceSheetControl
 import { CommoditiesController } from '../../../controllers/CommoditiesController';
 import { IncomeStatementController } from '../../../controllers/IncomeStatementController';
 import { RecurringController } from '../../../controllers/RecurringController';
+import { LiabilitiesController } from '../../../controllers/LiabilitiesController';
 // JournalController is replaced by plugin.journalStore
 // -----------------------------
 
@@ -29,6 +30,7 @@ export class UnifiedDashboardView extends ItemView {
 	commoditiesController: CommoditiesController;
 	incomeStatementController: IncomeStatementController;
 	recurringController: RecurringController;
+	liabilitiesController: LiabilitiesController;
 
 	constructor(leaf: WorkspaceLeaf, plugin: BeancountPlugin) {
 		super(leaf);
@@ -40,6 +42,7 @@ export class UnifiedDashboardView extends ItemView {
 		this.commoditiesController = new CommoditiesController(this.plugin);
 		this.incomeStatementController = new IncomeStatementController(this.plugin);
 		this.recurringController = new RecurringController(this.plugin);
+		this.liabilitiesController = new LiabilitiesController(this.plugin);
 	}
 
 	getViewType(): string { return UNIFIED_DASHBOARD_VIEW_TYPE; }
@@ -56,6 +59,7 @@ export class UnifiedDashboardView extends ItemView {
 				this.incomeStatementController.loadData(),
 				this.commoditiesController.loadData(),
 				this.recurringController.loadData(),
+				this.liabilitiesController.loadData(),
 				this.plugin.journalStore.refresh() // Use new store
 			]);
 		} catch (error) {
@@ -77,6 +81,7 @@ export class UnifiedDashboardView extends ItemView {
 				incomeStatementController: this.incomeStatementController,
 				commoditiesController: this.commoditiesController,
 				recurringController: this.recurringController,
+				liabilitiesController: this.liabilitiesController,
 				journalStore: this.plugin.journalStore, // Pass store instead of controller
 				plugin: this.plugin // Pass plugin instance
 			}
@@ -105,6 +110,7 @@ export class UnifiedDashboardView extends ItemView {
 		this.transactionController.handleFilterChange({}); // Load initial transactions
 		this.balanceSheetController.loadData();
 		this.incomeStatementController.loadData();
+		this.liabilitiesController.loadData();
 	}
 
 	async onClose() {


### PR DESCRIPTION
## Summary

Adds a new dashboard tab that surfaces loan-shaped accounts (Liabilities and Assets:Receivables sub-trees) with their contractual metadata read from `open` directives, alongside the live ledger balance.

## Recognised metadata keys (all optional)

| Key | Meaning |
|---|---|
| `loan-type` | Free-form classification (\`credit-card\`, \`mortgage\`, \`personal-loan\`, \`receivable\`, …) |
| `principal` | Original / face amount |
| `interest-rate` | Annual percentage as a number |
| `monthly-payment` | Amount in the account's currency |
| `due-day` | Day of month payment is due (1–31) |
| `counterparty` | Human label for the lender / debtor |

An account is included when it has any of these keys OR when its name starts with `Liabilities:` / `Assets:Receivables`. Role (liability vs receivable) is inferred from the path prefix or `loan-type`.

Each card shows: current balance, badge for loan type, key/value list (counterparty / principal / interest / monthly / next due date with a `in 12d` relative label), and an optional payoff bar (`1 - |balance| / |principal|`) clamped to `[0, 1]`.

The empty state surfaces a copy-pasteable example so a user with no loan-shaped accounts can opt in immediately.

## New surface

- `services/liabilities.service.ts` — pure parser for `open` directives + indented metadata, plus `nextDueDate` / `daysBetween` / `payoffFraction` helpers (no I/O, unit-testable).
- `queries/index.ts` — `getLoanBalancesQuery()` selects `sum(position)` per `Liabilities | Assets:Receivables` account.
- `controllers/LiabilitiesController.ts` — reads `accounts.beancount` via vault adapter, joins with the BQL balance result. BQL failures are soft (we still render metadata).
- `ui/partials/dashboard/LiabilitiesTab.svelte` — KPI header, section per role, card grid with payoff bar.
- Per-row "↗" button opens the accounts file at the open-directive line.

Wired into `UnifiedDashboardView` between **Income Statement** and **Commodities** tabs. The tab loads its data on view-open alongside the others.

## Implementation note

The empty-state container originally used the class `empty-state`, which collides with Obsidian's global `.empty-state` rule (`position: absolute; width: 100%; height: 100%; top: 0`) — same root cause as #122. Renamed to `loan-empty-state` to avoid that.

## Test plan

- [x] Empty vault (no loan-shaped accounts): renders the copy-pasteable guidance block, no console errors.
- [ ] Vault with `Liabilities:Credit:Visa` plus full metadata: card shows balance, loan-type badge, dl with all five fields, payoff bar.
- [ ] Vault with `Assets:Receivables:Maria`: same card, accent border green, "receivable" role.
- [ ] Mixed currencies across accounts: each card shows its own currency.
- [ ] Per-row "↗" jumps to the open-directive line in the accounts file.