### PR TITLE
feat(formatting+liabilities): currency-aware precision + Liabilities UX overhaul

### DIFF
--- a/src/controllers/CommoditiesController.ts
+++ b/src/controllers/CommoditiesController.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/index';
 import { PriceService } from '../services/price.service';
 import { Notice } from 'obsidian';
+import { formatCurrencyAmount, getCurrencyPrecision } from '../utils/currency-precision';
 
 /**
  * Interface representing metadata and state of a single commodity.
@@ -168,11 +169,12 @@ export class CommoditiesController {
         try {
             // Get operating currency from settings
             const operatingCurrency = this.plugin.settings.operatingCurrency || 'USD';
+            const priceStorage = getCurrencyPrecision(operatingCurrency).storage;
 
             // Execute all three queries in parallel
             const [commoditiesCSV, priceDataCSV, holdingsCSV] = await Promise.all([
                 this.plugin.runQuery(queries.getAllCommoditiesQuery()),
-                this.plugin.runQuery(queries.getCommoditiesPriceDataQuery(operatingCurrency)),
+                this.plugin.runQuery(queries.getCommoditiesPriceDataQuery(operatingCurrency, priceStorage)),
                 this.plugin.runQuery(queries.getCommoditiesHoldingsQuery(operatingCurrency))
             ]);
 
@@ -206,7 +208,9 @@ export class CommoditiesController {
                     metadata: {
                         ...(priceData?.logo ? { logo: priceData.logo } : {}),
                     },
-                    currentPrice: priceData?.price ? `${priceData.price} ${operatingCurrency}` : undefined,
+                    currentPrice: priceData?.price
+                        ? formatCurrencyAmount(parseFloat(priceData.price), operatingCurrency)
+                        : undefined,
                     logoUrl: priceData?.logo || null,
                     priceDate: priceData?.date || null,
                     isPriceLatest: priceData?.isLatest || false,

--- a/src/controllers/LiabilitiesController.ts
+++ b/src/controllers/LiabilitiesController.ts
@@ -1,0 +1,160 @@
+// src/controllers/LiabilitiesController.ts
+//
+// Reads `open` directives from the structured accounts file, parses
+// out loan-shaped metadata via liabilities.service, joins each
+// account with its current balance pulled from BQL, and exposes a
+// reactive Svelte store for the Liabilities & Receivables tab.
+
+import { writable, type Writable, get } from 'svelte/store';
+import type BeancountPlugin from '../main';
+import { parse as parseCsv } from 'csv-parse/sync';
+import * as queries from '../queries/index';
+import {
+    parseLoanAccounts,
+    type LoanAccount,
+} from '../services/liabilities.service';
+import { Logger } from '../utils/logger';
+
+export interface LoanRow extends LoanAccount {
+    /** Live balance from the ledger, in the account's currency. Null if no movements yet. */
+    currentBalance: number | null;
+    /** Display string for the live balance (e.g. "-12,500.00 UYU"). */
+    currentBalanceDisplay: string;
+}
+
+export interface LiabilitiesState {
+    isLoading: boolean;
+    error: string | null;
+    liabilities: LoanRow[];
+    receivables: LoanRow[];
+    /** Vault-relative path of the accounts file that was read. */
+    sourcePath: string;
+    /** Sum of liability balances in the operating currency, for a header KPI. */
+    totalLiabilities: number | null;
+    /** Sum of receivable balances in the operating currency, for a header KPI. */
+    totalReceivables: number | null;
+    /** Reporting currency. */
+    currency: string;
+}
+
+/**
+ * Resolve the accounts file path. We default to
+ * `<structuredFolder>/accounts.beancount` since the plugin's
+ * structured layout assumes that filename.
+ */
+function resolveAccountsPath(plugin: BeancountPlugin): string {
+    const folder = plugin.settings.structuredFolderName?.trim() || 'Finances';
+    return `${folder}/accounts.beancount`;
+}
+
+function parseBalanceCell(raw: string): { amount: number | null; currency: string | null } {
+    // BQL `sum(position)` returns a string like "12500.00 UYU" or
+    // "-200.00 UYU, 5.00 USD" for multi-currency positions. We split
+    // on the first comma and parse the first component.
+    if (!raw) return { amount: null, currency: null };
+    const first = raw.split(',')[0].trim();
+    const parts = first.split(/\s+/);
+    if (parts.length < 2) return { amount: null, currency: null };
+    const amount = parseFloat(parts[0].replace(/,/g, ''));
+    const currency = parts[1];
+    return { amount: isFinite(amount) ? amount : null, currency: currency || null };
+}
+
+function formatBalance(amount: number | null, currency: string | null): string {
+    if (amount === null) return '—';
+    const ccy = currency || '';
+    return `${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${ccy}`.trim();
+}
+
+export class LiabilitiesController {
+    private plugin: BeancountPlugin;
+    public state: Writable<LiabilitiesState>;
+
+    constructor(plugin: BeancountPlugin) {
+        this.plugin = plugin;
+        this.state = writable({
+            isLoading: true,
+            error: null,
+            liabilities: [],
+            receivables: [],
+            sourcePath: '',
+            totalLiabilities: null,
+            totalReceivables: null,
+            currency: plugin.settings.operatingCurrency || 'USD',
+        });
+    }
+
+    async loadData(): Promise<void> {
+        this.state.update(s => ({ ...s, isLoading: true, error: null }));
+        const sourcePath = resolveAccountsPath(this.plugin);
+
+        try {
+            // Parse account file metadata. If the file is missing the tab
+            // simply renders empty — this is a soft-fail situation, not an error.
+            const adapter = this.plugin.app.vault.adapter;
+            let accounts: LoanAccount[] = [];
+            if (await adapter.exists(sourcePath)) {
+                const content = await adapter.read(sourcePath);
+                accounts = parseLoanAccounts(content);
+            }
+
+            // Pull live balances. Treat BQL failure as soft: we still show metadata.
+            let balanceMap = new Map<string, { amount: number | null; currency: string | null }>();
+            try {
+                const csv = await this.plugin.runQuery(queries.getLoanBalancesQuery());
+                const cleaned = csv.replace(/\r/g, '').trim();
+                const records: string[][] = parseCsv(cleaned, { columns: false, skip_empty_lines: true, relax_column_count: true });
+                const firstRowIsHeader = records[0]?.[0]?.toLowerCase().includes('account');
+                const rows = firstRowIsHeader ? records.slice(1) : records;
+                for (const row of rows) {
+                    if (row.length < 2) continue;
+                    balanceMap.set(row[0], parseBalanceCell(row[1]));
+                }
+            } catch (e) {
+                Logger.log('[LiabilitiesController] balance query failed (continuing with metadata only):', e);
+            }
+
+            const enriched: LoanRow[] = accounts.map(acc => {
+                const bal = balanceMap.get(acc.account);
+                const amount = bal?.amount ?? null;
+                const currency = bal?.currency ?? acc.currency;
+                return {
+                    ...acc,
+                    currentBalance: amount,
+                    currentBalanceDisplay: formatBalance(amount, currency),
+                };
+            });
+
+            const liabilities = enriched.filter(r => r.role === 'liability');
+            const receivables = enriched.filter(r => r.role === 'receivable');
+
+            // Header KPIs: sum balances *in their declared currency* — we're
+            // not converting here (the Overview tab already shows the
+            // operating-currency aggregate via the existing query).
+            const sumByCurrency = (rows: LoanRow[]): number | null => {
+                const present = rows.filter(r => r.currentBalance !== null);
+                if (present.length === 0) return null;
+                return present.reduce((acc, r) => acc + (r.currentBalance ?? 0), 0);
+            };
+
+            this.state.set({
+                isLoading: false,
+                error: null,
+                liabilities,
+                receivables,
+                sourcePath,
+                totalLiabilities: sumByCurrency(liabilities),
+                totalReceivables: sumByCurrency(receivables),
+                currency: this.plugin.settings.operatingCurrency || 'USD',
+            });
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            Logger.log('[LiabilitiesController] loadData failed:', e);
+            this.state.update(s => ({ ...s, isLoading: false, error: msg }));
+        }
+    }
+
+    async refresh(): Promise<void> {
+        await this.loadData();
+    }
+}

--- a/src/controllers/LiabilitiesController.ts
+++ b/src/controllers/LiabilitiesController.ts
@@ -21,6 +21,16 @@ export interface LoanRow extends LoanAccount {
     currentBalance: number | null;
     /** Display string for the live balance (e.g. "-12,500.00 UYU"). */
     currentBalanceDisplay: string;
+    /**
+     * Where the displayed balance came from:
+     *   'posted'     – `sum(position)` returned a real number for this account
+     *   'principal'  – no postings yet, but the open directive carries a
+     *                  `principal` meta we surface as the implicit balance
+     *   'zero'       – BQL ran successfully and the account has no postings
+     *                  and no principal — genuinely 0
+     *   'unknown'    – BQL failed; we couldn't determine the balance
+     */
+    balanceSource: 'posted' | 'principal' | 'zero' | 'unknown';
 }
 
 export interface LiabilitiesState {
@@ -99,6 +109,7 @@ export class LiabilitiesController {
 
             // Pull live balances. Treat BQL failure as soft: we still show metadata.
             let balanceMap = new Map<string, { amount: number | null; currency: string | null }>();
+            let bqlSucceeded = false;
             try {
                 const csv = await this.plugin.runQuery(queries.getLoanBalancesQuery());
                 const cleaned = csv.replace(/\r/g, '').trim();
@@ -109,18 +120,55 @@ export class LiabilitiesController {
                     if (row.length < 2) continue;
                     balanceMap.set(row[0], parseBalanceCell(row[1]));
                 }
+                bqlSucceeded = true;
             } catch (e) {
                 Logger.log('[LiabilitiesController] balance query failed (continuing with metadata only):', e);
             }
 
             const enriched: LoanRow[] = accounts.map(acc => {
                 const bal = balanceMap.get(acc.account);
-                const amount = bal?.amount ?? null;
-                const currency = bal?.currency ?? acc.currency;
+                const hasPosted = !!bal && bal.amount !== null;
+
+                // Derive the displayed balance with this priority:
+                //   1. real posted balance (BQL `sum(position)`)
+                //   2. the `principal` meta — the contract face-value, which
+                //      is the user's mental model of "what's owed" when no
+                //      postings have been recorded yet
+                //   3. genuine zero when BQL succeeded with no postings AND
+                //      no principal (account just exists)
+                //   4. unknown ("—") when BQL itself failed
+                let amount: number | null;
+                let currency: string;
+                let source: LoanRow['balanceSource'];
+
+                if (hasPosted) {
+                    amount = bal!.amount;
+                    currency = bal!.currency ?? acc.currency;
+                    source = 'posted';
+                } else if (acc.principal !== null && acc.principal !== 0) {
+                    // For liabilities the user owes the principal (negative in
+                    // beancount sign); for receivables the user is owed it
+                    // (positive). Display value matches the absolute amount —
+                    // we let the role badge convey the direction.
+                    const sign = acc.role === 'liability' ? -1 : 1;
+                    amount = sign * Math.abs(acc.principal);
+                    currency = acc.currency;
+                    source = 'principal';
+                } else if (bqlSucceeded) {
+                    amount = 0;
+                    currency = acc.currency;
+                    source = 'zero';
+                } else {
+                    amount = null;
+                    currency = acc.currency;
+                    source = 'unknown';
+                }
+
                 return {
                     ...acc,
                     currentBalance: amount,
                     currentBalanceDisplay: formatBalance(amount, currency),
+                    balanceSource: source,
                 };
             });
 

--- a/src/controllers/LiabilitiesController.ts
+++ b/src/controllers/LiabilitiesController.ts
@@ -14,6 +14,7 @@ import {
     type LoanAccount,
 } from '../services/liabilities.service';
 import { Logger } from '../utils/logger';
+import { formatCurrencyAmount } from '../utils/currency-precision';
 
 export interface LoanRow extends LoanAccount {
     /** Live balance from the ledger, in the account's currency. Null if no movements yet. */
@@ -61,9 +62,7 @@ function parseBalanceCell(raw: string): { amount: number | null; currency: strin
 }
 
 function formatBalance(amount: number | null, currency: string | null): string {
-    if (amount === null) return '—';
-    const ccy = currency || '';
-    return `${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${ccy}`.trim();
+    return formatCurrencyAmount(amount, currency);
 }
 
 export class LiabilitiesController {

--- a/src/controllers/OverviewController.ts
+++ b/src/controllers/OverviewController.ts
@@ -5,6 +5,7 @@ import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
 import { parseSingleValue } from '../utils/index'; // Import helpers
 import { Logger } from '../utils/logger';
+import { formatCurrencyAmount, getCurrencyPrecision } from '../utils/currency-precision';
 
 /**
  * Interface representing the state of the Overview dashboard.
@@ -75,11 +76,14 @@ export class OverviewController {
 		}
 
 		try {
+			// Round in BQL at the currency's natural storage precision so we
+			// don't lose meaningful digits before parsing (e.g. BTC).
+			const storage = getCurrencyPrecision(reportingCurrency).storage;
 			const [netWorthResult, incomeResult, expensesResult, savingsResult] = await Promise.all([
-				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getThisMonthIncomeQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getThisMonthExpensesQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getThisMonthSavingsQuery(reportingCurrency, 2)),
+				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, storage)),
+				this.plugin.runQuery(queries.getThisMonthIncomeQuery(reportingCurrency, storage)),
+				this.plugin.runQuery(queries.getThisMonthExpensesQuery(reportingCurrency, storage)),
+				this.plugin.runQuery(queries.getThisMonthSavingsQuery(reportingCurrency, storage)),
 			]);
 
 			// Process KPI Data
@@ -92,9 +96,9 @@ export class OverviewController {
 			const savingsNum = parseFloat(parseSingleValue(savingsResult)) || 0;
 
 			const newState: Partial<OverviewState> = {
-				netWorth: `${netWorthNum.toFixed(2)} ${reportingCurrency}`,
-				monthlyIncome: `${incomeAmount.toFixed(2)} ${reportingCurrency}`,
-				monthlyExpenses: `${expensesAmount.toFixed(2)} ${reportingCurrency}`,
+				netWorth: formatCurrencyAmount(netWorthNum, reportingCurrency),
+				monthlyIncome: formatCurrencyAmount(incomeAmount, reportingCurrency),
+				monthlyExpenses: formatCurrencyAmount(expensesAmount, reportingCurrency),
 				savingsRate: incomeAmount > 0 ? `${((savingsNum / incomeAmount) * 100).toFixed(0)}%` : 'N/A',
 				currency: reportingCurrency,
 			};

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -205,3 +205,13 @@ export function getAllPricesQuery(limit: number = 100): string {
 export function getAllCurrenciesQuery(): string {
 	return `SELECT distinct(currency) AS currency_`;
 }
+
+/**
+ * Current balance per account in the Liabilities and Assets:Receivables
+ * sub-trees, returned as a position (with currency). Used by the
+ * Liabilities & Receivables tab to show the live balance alongside
+ * the contractual metadata read from the accounts file.
+ */
+export function getLoanBalancesQuery(): string {
+	return `SELECT account, sum(position) WHERE account ~ '^(Liabilities|Assets:Receivables)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -170,8 +170,8 @@ export function getAllCommoditiesQuery(): string {
 	return `SELECT name AS name_ FROM #commodities GROUP BY name`;
 }
 
-export function getCommoditiesPriceDataQuery(currency: string): string {
-	return `SELECT last(date) AS date_, last(currency) AS currency_, round(getprice(last(currency), '${currency}'),2) AS price_, currency_meta(last(currency), 'logo') AS logo_, bool(today()-1<last(date)) AS islatest_ FROM #prices GROUP BY currency`;
+export function getCommoditiesPriceDataQuery(currency: string, rounding: number = 8): string {
+	return `SELECT last(date) AS date_, last(currency) AS currency_, round(getprice(last(currency), '${currency}'),${rounding}) AS price_, currency_meta(last(currency), 'logo') AS logo_, bool(today()-1<last(date)) AS islatest_ FROM #prices GROUP BY currency`;
 }
 
 /**
@@ -194,8 +194,8 @@ export function getPriceHistoryQuery(commodity: string): string {
 	return `SELECT date, position, meta('filename') FROM #prices WHERE currency='${commodity}' ORDER BY date DESC`;
 }
 
-export function getStaleCommoditiesQuery(daysOld: number, currency: string): string {
-	return `SELECT currency AS commodity_, last(date) AS lastdate_, round(getprice(last(currency), '${currency}'),2) AS price_ FROM #prices GROUP BY currency HAVING today() - last(date) > ${daysOld}`;
+export function getStaleCommoditiesQuery(daysOld: number, currency: string, rounding: number = 8): string {
+	return `SELECT currency AS commodity_, last(date) AS lastdate_, round(getprice(last(currency), '${currency}'),${rounding}) AS price_ FROM #prices GROUP BY currency HAVING today() - last(date) > ${daysOld}`;
 }
 
 export function getAllPricesQuery(limit: number = 100): string {

--- a/src/services/liabilities.service.ts
+++ b/src/services/liabilities.service.ts
@@ -55,10 +55,21 @@ export interface LoanAccount {
     interestRate: number | null;
     /** Monthly payment amount in the account currency. */
     monthlyPayment: number | null;
-    /** Day-of-month the payment is due (1–31). */
+    /** Day-of-month the payment is due (1–31). For recurring loans only. */
     dueDay: number | null;
     /** Optional funding/destination account override read from the `funding-account` meta. */
     fundingAccount: string | null;
+    /**
+     * Payment schedule. `'recurring'` = pay back monthly via
+     * `monthly-payment` + `due-day`. `'one-time'` = single lump-sum
+     * by `payoff-date` for `payoff-amount`. Inferred from which
+     * metadata keys are present (one-time wins if both sets exist).
+     */
+    paymentMode: 'recurring' | 'one-time';
+    /** ISO YYYY-MM-DD payoff date for one-time loans. Read from the `payoff-date` meta. */
+    payoffDate: string | null;
+    /** Total amount to pay on payoff-date. Read from the `payoff-amount` meta. */
+    payoffAmount: number | null;
     /** 1-based source line number of the open directive (for "open file at rule" jumps). */
     sourceLine?: number;
 }
@@ -118,6 +129,15 @@ export function parseLoanAccounts(content: string): LoanAccount[] {
             account.startsWith('Assets:Receivables');
         if (isLoanShaped) {
             const dueDay = meta['due-day'] ? toNumber(meta['due-day']) : null;
+            const payoffDateRaw = meta['payoff-date'] ? unquote(meta['payoff-date']).trim() : '';
+            const payoffDate = /^\d{4}-\d{2}-\d{2}$/.test(payoffDateRaw) ? payoffDateRaw : null;
+            const payoffAmount = meta['payoff-amount'] ? toNumber(meta['payoff-amount']) : null;
+            const monthlyPayment = meta['monthly-payment'] ? toNumber(meta['monthly-payment']) : null;
+            // Mode inference: explicit payoff metadata always wins; otherwise
+            // the presence of monthly-payment / due-day implies recurring.
+            const paymentMode: 'recurring' | 'one-time' = (payoffDate !== null || payoffAmount !== null)
+                ? 'one-time'
+                : 'recurring';
             out.push({
                 account,
                 currency,
@@ -127,9 +147,12 @@ export function parseLoanAccounts(content: string): LoanAccount[] {
                 counterparty: meta['counterparty'] ? unquote(meta['counterparty']) : null,
                 principal: meta['principal'] ? toNumber(meta['principal']) : null,
                 interestRate: meta['interest-rate'] ? toNumber(meta['interest-rate']) : null,
-                monthlyPayment: meta['monthly-payment'] ? toNumber(meta['monthly-payment']) : null,
+                monthlyPayment,
                 dueDay: dueDay !== null && dueDay >= 1 && dueDay <= 31 ? Math.round(dueDay) : null,
                 fundingAccount: meta['funding-account'] ? unquote(meta['funding-account']) : null,
+                paymentMode,
+                payoffDate,
+                payoffAmount,
                 sourceLine: startLine,
             });
         }
@@ -250,10 +273,18 @@ export interface LoanFormDraft {
     monthlyPayment: number | null;
     dueDay: number | null;
     fundingAccount: string | null;
+    paymentMode: 'recurring' | 'one-time';
+    payoffDate: string | null;
+    payoffAmount: number | null;
 }
 
+// Order matters for the on-disk layout; payment-schedule fields cluster
+// just below the "what is this loan" identity fields.
 const META_KEY_ORDER: Array<keyof LoanFormDraft> = [
-    'loanType', 'counterparty', 'principal', 'interestRate', 'monthlyPayment', 'dueDay', 'fundingAccount',
+    'loanType', 'counterparty', 'principal', 'interestRate',
+    'monthlyPayment', 'dueDay',
+    'payoffDate', 'payoffAmount',
+    'fundingAccount',
 ];
 
 const META_KEY_TO_BEANCOUNT: Record<string, string> = {
@@ -263,10 +294,24 @@ const META_KEY_TO_BEANCOUNT: Record<string, string> = {
     interestRate: 'interest-rate',
     monthlyPayment: 'monthly-payment',
     dueDay: 'due-day',
+    payoffDate: 'payoff-date',
+    payoffAmount: 'payoff-amount',
     fundingAccount: 'funding-account',
 };
 
-const STRING_META_KEYS: ReadonlySet<string> = new Set(['loanType', 'counterparty', 'fundingAccount']);
+const STRING_META_KEYS: ReadonlySet<string> = new Set(['loanType', 'counterparty', 'fundingAccount', 'payoffDate']);
+
+/**
+ * Strip fields that don't apply to the chosen payment mode so they
+ * don't accidentally land in the on-disk metadata. Used by the modal
+ * before calling formatLoanOpenDirective / applyLoanEdits.
+ */
+export function pruneDraftForMode(draft: LoanFormDraft): LoanFormDraft {
+    if (draft.paymentMode === 'recurring') {
+        return { ...draft, payoffDate: null, payoffAmount: null };
+    }
+    return { ...draft, monthlyPayment: null, dueDay: null };
+}
 
 /**
  * Format a single open-directive block from a draft, e.g.:

--- a/src/services/liabilities.service.ts
+++ b/src/services/liabilities.service.ts
@@ -1,0 +1,218 @@
+// src/services/liabilities.service.ts
+//
+// Parses Beancount `open` directives plus their indented metadata to
+// surface accounts that represent loans, credit lines, mortgages or
+// receivables on a dedicated dashboard tab. Pure functions only — no
+// I/O — so the parser is unit-testable.
+//
+// Recognised metadata keys (all optional; account is included if it
+// has *any* of them OR if its name starts with "Liabilities:" or
+// "Assets:Receivables:"):
+//
+//   loan-type:        free-form string ("credit-card", "mortgage",
+//                     "personal-loan", "receivable", etc.)
+//   principal:        original amount (number, no currency suffix —
+//                     the account's open-currency is used)
+//   interest-rate:    annual percentage as a number (e.g. 29.5)
+//   monthly-payment:  number (no currency suffix)
+//   due-day:          day of month (1–31) when payment is due
+//   counterparty:     human label ("Banco Santander", "Maria Esther")
+//
+// Source format example:
+//
+//   2026-01-01 open Liabilities:Credit:Visa  USD
+//     loan-type: "credit-card"
+//     principal: 50000
+//     interest-rate: 29.5
+//     monthly-payment: 5000
+//     due-day: 10
+//     counterparty: "Banco Santander"
+//
+//   2026-02-01 open Assets:Receivables:Maria  UYU
+//     loan-type: "receivable"
+//     principal: 12000
+//     monthly-payment: 1000
+//     due-day: 15
+
+export type LoanRole = 'liability' | 'receivable';
+
+export interface LoanAccount {
+    /** Full account path (e.g. "Liabilities:Credit:Visa"). */
+    account: string;
+    /** Currency declared on the open directive (first declared currency wins). */
+    currency: string;
+    /** ISO open-date. */
+    openDate: string;
+    /** Whether this account represents money the user owes (liability) or is owed (receivable). */
+    role: LoanRole;
+    /** Free-form loan classification (credit-card, mortgage, personal-loan, receivable, …). */
+    loanType: string | null;
+    /** Counterparty label (bank, lender, friend, …). */
+    counterparty: string | null;
+    /** Original / face amount of the loan. */
+    principal: number | null;
+    /** Annual interest rate as a number (e.g. 29.5 for 29.5%). */
+    interestRate: number | null;
+    /** Monthly payment amount in the account currency. */
+    monthlyPayment: number | null;
+    /** Day-of-month the payment is due (1–31). */
+    dueDay: number | null;
+    /** 1-based source line number of the open directive (for "open file at rule" jumps). */
+    sourceLine?: number;
+}
+
+const OPEN_DIRECTIVE = /^(\d{4}-\d{2}-\d{2})\s+open\s+([A-Z][A-Za-z0-9:_-]*)\s*([A-Z][A-Z0-9'._-]*)?(?:\s+"[^"]*")?\s*$/;
+const META_LINE = /^\s+([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$/;
+
+/**
+ * Strip Beancount string quoting from a metadata value. Numeric and
+ * bare values pass through unchanged. Returns `null` for empty.
+ */
+function unquote(raw: string): string {
+    const t = raw.trim();
+    if (!t) return '';
+    if (t.startsWith('"') && t.endsWith('"') && t.length >= 2) {
+        return t.slice(1, -1);
+    }
+    return t;
+}
+
+function toNumber(raw: string): number | null {
+    const t = unquote(raw).trim();
+    if (!t) return null;
+    const n = parseFloat(t);
+    return isFinite(n) ? n : null;
+}
+
+function inferRole(account: string, loanType: string | null): LoanRole {
+    if (account.startsWith('Liabilities:') || account === 'Liabilities') return 'liability';
+    if (account.startsWith('Assets:Receivables') || /^Receivables(:|$)/.test(account)) return 'receivable';
+    if ((loanType || '').toLowerCase().includes('receivable')) return 'receivable';
+    return 'liability';
+}
+
+/**
+ * Parse the contents of an accounts file (typically accounts.beancount)
+ * for `open` directives whose metadata identifies them as loan-like.
+ * Lines that don't match the directive shape are silently ignored.
+ */
+export function parseLoanAccounts(content: string): LoanAccount[] {
+    const out: LoanAccount[] = [];
+    const lines = content.split(/\r?\n/);
+
+    let pending: { startLine: number; openDate: string; account: string; currency: string; meta: Record<string, string> } | null = null;
+
+    const flush = () => {
+        if (!pending) return;
+        const { account, openDate, currency, meta, startLine } = pending;
+        const loanType = meta['loan-type'] ? unquote(meta['loan-type']) : null;
+        const isLoanShaped =
+            loanType !== null ||
+            'principal' in meta ||
+            'monthly-payment' in meta ||
+            'interest-rate' in meta ||
+            'due-day' in meta ||
+            account.startsWith('Liabilities:') ||
+            account.startsWith('Assets:Receivables');
+        if (isLoanShaped) {
+            const dueDay = meta['due-day'] ? toNumber(meta['due-day']) : null;
+            out.push({
+                account,
+                currency,
+                openDate,
+                role: inferRole(account, loanType),
+                loanType,
+                counterparty: meta['counterparty'] ? unquote(meta['counterparty']) : null,
+                principal: meta['principal'] ? toNumber(meta['principal']) : null,
+                interestRate: meta['interest-rate'] ? toNumber(meta['interest-rate']) : null,
+                monthlyPayment: meta['monthly-payment'] ? toNumber(meta['monthly-payment']) : null,
+                dueDay: dueDay !== null && dueDay >= 1 && dueDay <= 31 ? Math.round(dueDay) : null,
+                sourceLine: startLine,
+            });
+        }
+        pending = null;
+    };
+
+    for (let i = 0; i < lines.length; i++) {
+        const raw = lines[i];
+        const trimmed = raw.trim();
+
+        if (!trimmed || trimmed.startsWith(';')) {
+            // blank / comment line outside an open block resets pending only at the boundary
+            // (we still allow blank lines after metadata to terminate the block).
+            if (pending && !trimmed) flush();
+            continue;
+        }
+
+        const openMatch = OPEN_DIRECTIVE.exec(raw);
+        if (openMatch) {
+            // Flush the previous block if any, then start a new pending one.
+            flush();
+            const [, openDate, account, currency] = openMatch;
+            pending = {
+                startLine: i + 1,
+                openDate,
+                account,
+                currency: currency || '',
+                meta: {},
+            };
+            continue;
+        }
+
+        if (pending) {
+            const metaMatch = META_LINE.exec(raw);
+            if (metaMatch) {
+                pending.meta[metaMatch[1]] = metaMatch[2];
+                continue;
+            }
+            // Non-metadata, non-open content: terminate the block.
+            flush();
+        }
+    }
+    flush();
+    return out;
+}
+
+/**
+ * Compute the next due date (YYYY-MM-DD) for a loan account, given a
+ * reference date. If `dueDay` falls today, today is returned. If it
+ * already passed this month, the same day next month is used (clamped
+ * to the month-end for short months).
+ */
+export function nextDueDate(dueDay: number | null, today: string = new Date().toISOString().slice(0, 10)): string | null {
+    if (dueDay === null || !isFinite(dueDay)) return null;
+    const [y, m, d] = today.split('-').map(Number);
+    const clamp = (year: number, month: number, day: number): string => {
+        const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+        const safe = Math.min(Math.max(1, Math.round(day)), lastDay);
+        return `${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${safe.toString().padStart(2, '0')}`;
+    };
+    if (d <= dueDay) return clamp(y, m, dueDay);
+    // Otherwise, roll forward one month.
+    const nextYear = m === 12 ? y + 1 : y;
+    const nextMonth = m === 12 ? 1 : m + 1;
+    return clamp(nextYear, nextMonth, dueDay);
+}
+
+/**
+ * Days between two ISO dates (b - a). Negative means a is after b.
+ */
+export function daysBetween(a: string, b: string): number {
+    const da = new Date(a + 'T00:00:00Z').getTime();
+    const db = new Date(b + 'T00:00:00Z').getTime();
+    return Math.round((db - da) / 86400000);
+}
+
+/**
+ * Compute the user-facing payoff fraction (0..1) given a balance and
+ * a principal. For liabilities the balance is typically negative
+ * (Beancount credit) and shrinks toward zero as it's paid off; for
+ * receivables it's positive and shrinks the same way. We normalise
+ * by absolute values so the fraction is meaningful in both cases.
+ * Returns `null` if principal is missing or zero.
+ */
+export function payoffFraction(currentBalance: number | null, principal: number | null): number | null {
+    if (principal === null || principal === 0 || currentBalance === null) return null;
+    const remaining = Math.abs(currentBalance) / Math.abs(principal);
+    return Math.max(0, Math.min(1, 1 - remaining));
+}

--- a/src/services/liabilities.service.ts
+++ b/src/services/liabilities.service.ts
@@ -57,6 +57,8 @@ export interface LoanAccount {
     monthlyPayment: number | null;
     /** Day-of-month the payment is due (1–31). */
     dueDay: number | null;
+    /** Optional funding/destination account override read from the `funding-account` meta. */
+    fundingAccount: string | null;
     /** 1-based source line number of the open directive (for "open file at rule" jumps). */
     sourceLine?: number;
 }
@@ -127,6 +129,7 @@ export function parseLoanAccounts(content: string): LoanAccount[] {
                 interestRate: meta['interest-rate'] ? toNumber(meta['interest-rate']) : null,
                 monthlyPayment: meta['monthly-payment'] ? toNumber(meta['monthly-payment']) : null,
                 dueDay: dueDay !== null && dueDay >= 1 && dueDay <= 31 ? Math.round(dueDay) : null,
+                fundingAccount: meta['funding-account'] ? unquote(meta['funding-account']) : null,
                 sourceLine: startLine,
             });
         }
@@ -215,4 +218,157 @@ export function payoffFraction(currentBalance: number | null, principal: number 
     if (principal === null || principal === 0 || currentBalance === null) return null;
     const remaining = Math.abs(currentBalance) / Math.abs(principal);
     return Math.max(0, Math.min(1, 1 - remaining));
+}
+
+/**
+ * Naive months-to-payoff estimate: |balance| / |monthlyPayment|.
+ * Doesn't compound interest — back-of-envelope ETA only. Returns null
+ * when either input is missing or zero.
+ */
+export function monthsRemaining(currentBalance: number | null, monthlyPayment: number | null): number | null {
+    if (currentBalance === null || monthlyPayment === null || monthlyPayment === 0) return null;
+    const months = Math.abs(currentBalance) / Math.abs(monthlyPayment);
+    if (!isFinite(months) || months <= 0) return null;
+    return months;
+}
+
+// --- Write-back helpers (used by the in-tab Add/Edit loan modal) ---
+
+/**
+ * Editable shape used by the loan modal. `account` is required (the
+ * unique key) and `currency` is required (drives the open-directive
+ * declaration). All other fields are optional metadata.
+ */
+export interface LoanFormDraft {
+    account: string;
+    currency: string;
+    openDate: string; // YYYY-MM-DD
+    loanType: string | null;
+    counterparty: string | null;
+    principal: number | null;
+    interestRate: number | null;
+    monthlyPayment: number | null;
+    dueDay: number | null;
+    fundingAccount: string | null;
+}
+
+const META_KEY_ORDER: Array<keyof LoanFormDraft> = [
+    'loanType', 'counterparty', 'principal', 'interestRate', 'monthlyPayment', 'dueDay', 'fundingAccount',
+];
+
+const META_KEY_TO_BEANCOUNT: Record<string, string> = {
+    loanType: 'loan-type',
+    counterparty: 'counterparty',
+    principal: 'principal',
+    interestRate: 'interest-rate',
+    monthlyPayment: 'monthly-payment',
+    dueDay: 'due-day',
+    fundingAccount: 'funding-account',
+};
+
+const STRING_META_KEYS: ReadonlySet<string> = new Set(['loanType', 'counterparty', 'fundingAccount']);
+
+/**
+ * Format a single open-directive block from a draft, e.g.:
+ *
+ *   2026-01-15 open Liabilities:Credit:Visa  USD
+ *     loan-type: "credit-card"
+ *     principal: 5000
+ *     ...
+ */
+export function formatLoanOpenDirective(draft: LoanFormDraft): string {
+    const lines: string[] = [];
+    const head = `${draft.openDate} open ${draft.account}` + (draft.currency ? `  ${draft.currency}` : '');
+    lines.push(head);
+
+    for (const key of META_KEY_ORDER) {
+        const raw = draft[key];
+        if (raw === null || raw === undefined || raw === '') continue;
+        const beancountKey = META_KEY_TO_BEANCOUNT[key];
+        if (!beancountKey) continue;
+        const value = STRING_META_KEYS.has(key as string)
+            ? `"${String(raw).replace(/"/g, '\\"')}"`
+            : String(raw);
+        lines.push(`  ${beancountKey}: ${value}`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Surgical rewrite of an accounts.beancount file: replace, insert, or
+ * delete loan-account blocks while leaving every other line exactly
+ * where the user wrote it.
+ *
+ *   - `edits` is keyed by the original account path. Each entry is the
+ *     desired new state, or `null` to remove the block.
+ *   - `additions` is the list of brand-new loan accounts to append at
+ *     the bottom (separated by a blank line for breathing room).
+ *
+ * A "loan-account block" is the open-directive line plus the indented
+ * metadata lines that immediately follow it.
+ */
+export function applyLoanEdits(
+    originalContent: string,
+    edits: Record<string, LoanFormDraft | null>,
+    additions: LoanFormDraft[] = [],
+): string {
+    const lines = originalContent.split(/\r?\n/);
+    const trailingNewline = originalContent.endsWith('\n');
+    const accounts = parseLoanAccounts(originalContent);
+
+    // Map original account → block range [startLine0, endLine0]
+    const blockRanges = new Map<string, [number, number]>();
+    for (const acc of accounts) {
+        const start = (acc.sourceLine ?? 1) - 1;
+        let end = start;
+        for (let i = start + 1; i < lines.length; i++) {
+            if ((lines[i].startsWith(' ') || lines[i].startsWith('\t')) && META_LINE.test(lines[i])) {
+                end = i;
+                continue;
+            }
+            break;
+        }
+        blockRanges.set(acc.account, [start, end]);
+    }
+
+    const accountByStart = new Map<number, string>();
+    for (const [account, [start]] of blockRanges) {
+        accountByStart.set(start, account);
+    }
+
+    const out: string[] = [];
+    let i = 0;
+    while (i < lines.length) {
+        const account = accountByStart.get(i);
+        if (account && account in edits) {
+            const desired = edits[account];
+            const [, end] = blockRanges.get(account)!;
+            if (desired === null) {
+                i = end + 1;
+                if (out.length > 0 && out[out.length - 1].trim() === '' &&
+                    i < lines.length && lines[i].trim() === '') {
+                    i += 1;
+                }
+                continue;
+            }
+            out.push(formatLoanOpenDirective(desired));
+            i = end + 1;
+            continue;
+        }
+        out.push(lines[i]);
+        i += 1;
+    }
+
+    if (additions.length > 0) {
+        if (out.length > 0 && out[out.length - 1].trim() !== '') out.push('');
+        for (let k = 0; k < additions.length; k++) {
+            if (k > 0) out.push('');
+            out.push(formatLoanOpenDirective(additions[k]));
+        }
+    }
+
+    let result = out.join('\n');
+    if (trailingNewline && !result.endsWith('\n')) result += '\n';
+    return result;
 }

--- a/src/ui/modals/LoanEditModal.svelte
+++ b/src/ui/modals/LoanEditModal.svelte
@@ -1,0 +1,294 @@
+<!-- src/ui/modals/LoanEditModal.svelte -->
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import type { LoanFormDraft } from '../../services/liabilities.service';
+
+	export let initial: LoanFormDraft;
+	export let mode: 'add' | 'edit' = 'add';
+	export let accounts: string[] = [];
+	export let currencies: string[] = [];
+
+	const dispatch = createEventDispatcher();
+
+	const LOAN_TYPES = [
+		'credit-card', 'mortgage', 'personal-loan', 'auto-loan',
+		'student-loan', 'line-of-credit', 'receivable', 'other',
+	];
+
+	let draft: LoanFormDraft = { ...initial, loanType: initial.loanType ?? 'credit-card' };
+	let errors: Record<string, string> = {};
+
+	$: assetAccounts = accounts.filter(a => a.startsWith('Assets'));
+	$: incomeAccounts = accounts.filter(a => a.startsWith('Income'));
+	$: fundingAccounts = [...assetAccounts, ...incomeAccounts];
+
+	function validate(): boolean {
+		errors = {};
+		const path = (draft.account ?? '').trim();
+		if (!path) errors.account = 'Account path is required';
+		else if (!/^[A-Z][A-Za-z0-9:_-]*$/.test(path)) errors.account = 'Format: \'TopLevel:Sub:Leaf\' (must start with capital)';
+
+		const ccy = (draft.currency ?? '').trim();
+		if (!ccy) errors.currency = 'Currency is required';
+		else if (!/^[A-Z][A-Z0-9'._-]*$/.test(ccy)) errors.currency = 'Currency must be uppercase code';
+
+		if (!/^\d{4}-\d{2}-\d{2}$/.test((draft.openDate ?? '').trim())) errors.openDate = 'Must be YYYY-MM-DD';
+
+		if (draft.dueDay !== null && (draft.dueDay < 1 || draft.dueDay > 31))
+			errors.dueDay = 'Day must be 1–31';
+		if (draft.principal !== null && draft.principal < 0)
+			errors.principal = 'Must be ≥ 0';
+		if (draft.monthlyPayment !== null && draft.monthlyPayment < 0)
+			errors.monthlyPayment = 'Must be ≥ 0';
+		if (draft.interestRate !== null && draft.interestRate < 0)
+			errors.interestRate = 'Must be ≥ 0';
+
+		return Object.keys(errors).length === 0;
+	}
+
+	function handleSave() {
+		if (!validate()) return;
+		const cleaned: LoanFormDraft = {
+			account: draft.account.trim(),
+			currency: draft.currency.trim().toUpperCase(),
+			openDate: draft.openDate.trim(),
+			loanType: (draft.loanType ?? '').trim() || null,
+			counterparty: (draft.counterparty ?? '').trim() || null,
+			principal: numberOrNull(draft.principal),
+			interestRate: numberOrNull(draft.interestRate),
+			monthlyPayment: numberOrNull(draft.monthlyPayment),
+			dueDay: draft.dueDay !== null && draft.dueDay !== undefined ? Math.round(Number(draft.dueDay)) : null,
+			fundingAccount: (draft.fundingAccount ?? '').trim() || null,
+		};
+		dispatch('save', { draft: cleaned, originalAccount: initial.account });
+	}
+
+	function numberOrNull(v: number | null | undefined): number | null {
+		if (v === null || v === undefined || v === ('' as any)) return null;
+		const n = Number(v);
+		return isFinite(n) ? n : null;
+	}
+
+	function handleCancel() {
+		dispatch('cancel');
+	}
+
+	function handleDelete() {
+		if (mode !== 'edit') return;
+		if (!confirm(`Remove loan account "${initial.account}"?\n\nThe open directive and metadata will be deleted from accounts.beancount. Past transactions referencing the account stay intact.`)) return;
+		dispatch('delete', { originalAccount: initial.account });
+	}
+</script>
+
+<div class="loan-modal">
+	<div class="row">
+		<label class="field grow">
+			<span>Account path <em>*</em></span>
+			<input
+				type="text"
+				placeholder="Liabilities:Credit:Visa"
+				list="loan-accounts"
+				bind:value={draft.account}
+				class:error={errors.account}
+			/>
+			<datalist id="loan-accounts">
+				{#each accounts.filter(a => a.startsWith('Liabilities') || a.startsWith('Assets:Receivables')) as a}
+					<option value={a} />
+				{/each}
+			</datalist>
+			{#if errors.account}<span class="error-msg">{errors.account}</span>{/if}
+		</label>
+
+		<label class="field narrow">
+			<span>Currency <em>*</em></span>
+			<input
+				type="text"
+				list="loan-currencies"
+				placeholder="USD"
+				bind:value={draft.currency}
+				class:error={errors.currency}
+			/>
+			<datalist id="loan-currencies">
+				{#each currencies as c}<option value={c} />{/each}
+			</datalist>
+			{#if errors.currency}<span class="error-msg">{errors.currency}</span>{/if}
+		</label>
+	</div>
+
+	<div class="row">
+		<label class="field">
+			<span>Open date <em>*</em></span>
+			<input
+				type="date"
+				bind:value={draft.openDate}
+				class:error={errors.openDate}
+			/>
+			{#if errors.openDate}<span class="error-msg">{errors.openDate}</span>{/if}
+		</label>
+
+		<label class="field">
+			<span>Loan type</span>
+			<select bind:value={draft.loanType}>
+				{#each LOAN_TYPES as t}<option value={t}>{t}</option>{/each}
+			</select>
+		</label>
+
+		<label class="field grow">
+			<span>Counterparty</span>
+			<input
+				type="text"
+				placeholder="Banco Santander, Maria Esther, …"
+				bind:value={draft.counterparty}
+			/>
+		</label>
+	</div>
+
+	<div class="row">
+		<label class="field">
+			<span>Principal</span>
+			<input
+				type="number"
+				step="any"
+				placeholder="0"
+				bind:value={draft.principal}
+				class:error={errors.principal}
+			/>
+			{#if errors.principal}<span class="error-msg">{errors.principal}</span>{/if}
+		</label>
+
+		<label class="field">
+			<span>Interest rate (% APR)</span>
+			<input
+				type="number"
+				step="any"
+				placeholder="0"
+				bind:value={draft.interestRate}
+				class:error={errors.interestRate}
+			/>
+			{#if errors.interestRate}<span class="error-msg">{errors.interestRate}</span>{/if}
+		</label>
+
+		<label class="field">
+			<span>Monthly payment</span>
+			<input
+				type="number"
+				step="any"
+				placeholder="0"
+				bind:value={draft.monthlyPayment}
+				class:error={errors.monthlyPayment}
+			/>
+			{#if errors.monthlyPayment}<span class="error-msg">{errors.monthlyPayment}</span>{/if}
+		</label>
+
+		<label class="field narrow">
+			<span>Due day</span>
+			<input
+				type="number"
+				min="1"
+				max="31"
+				placeholder="1–31"
+				bind:value={draft.dueDay}
+				class:error={errors.dueDay}
+			/>
+			{#if errors.dueDay}<span class="error-msg">{errors.dueDay}</span>{/if}
+		</label>
+	</div>
+
+	<div class="row">
+		<label class="field grow">
+			<span>Funding account (used by the recurring widget when synthesising payment rules)</span>
+			<input
+				type="text"
+				list="loan-funding"
+				placeholder="Assets:Banking:… or Income:Repayment"
+				bind:value={draft.fundingAccount}
+			/>
+			<datalist id="loan-funding">
+				{#each fundingAccounts as a}<option value={a} />{/each}
+			</datalist>
+		</label>
+	</div>
+
+	<div class="footer">
+		{#if mode === 'edit'}
+			<button class="danger" on:click={handleDelete} title="Delete this account from accounts.beancount">Delete</button>
+		{/if}
+		<div class="footer-spacer"></div>
+		<button on:click={handleCancel}>Cancel</button>
+		<button class="cta" on:click={handleSave}>{mode === 'add' ? 'Add loan' : 'Save changes'}</button>
+	</div>
+</div>
+
+<style>
+	.loan-modal {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+	}
+	.row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-4-3);
+	}
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex: 1 1 160px;
+		min-width: 0;
+	}
+	.field.grow { flex: 1 1 240px; }
+	.field.narrow { flex: 0 0 120px; }
+	.field span {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+	.field em {
+		color: var(--color-red);
+		font-style: normal;
+	}
+	.field input,
+	.field select {
+		width: 100%;
+		padding: 6px 8px;
+		border-radius: var(--radius-s);
+		border: 1px solid var(--background-modifier-border);
+		background: var(--background-primary);
+		color: var(--text-normal);
+	}
+	.field input.error,
+	.field select.error {
+		border-color: var(--color-red);
+	}
+	.error-msg {
+		color: var(--color-red);
+		font-size: var(--font-ui-smaller);
+	}
+
+	.footer {
+		display: flex;
+		gap: 8px;
+		padding-top: var(--size-4-3);
+		border-top: 1px solid var(--background-modifier-border);
+		align-items: center;
+	}
+	.footer-spacer { flex: 1; }
+	button {
+		padding: 6px 14px;
+		border-radius: var(--radius-s);
+		cursor: pointer;
+	}
+	.cta {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+		border: 1px solid var(--interactive-accent);
+	}
+	.danger {
+		background: transparent;
+		color: var(--color-red);
+		border: 1px solid var(--color-red);
+	}
+	.danger:hover {
+		background: color-mix(in srgb, var(--color-red), transparent 92%);
+	}
+</style>

--- a/src/ui/modals/LoanEditModal.svelte
+++ b/src/ui/modals/LoanEditModal.svelte
@@ -101,16 +101,17 @@
 
 		<label class="field narrow">
 			<span>Currency <em>*</em></span>
-			<input
-				type="text"
-				list="loan-currencies"
-				placeholder="USD"
+			<select
 				bind:value={draft.currency}
 				class:error={errors.currency}
-			/>
-			<datalist id="loan-currencies">
-				{#each currencies as c}<option value={c} />{/each}
-			</datalist>
+			>
+				{#if draft.currency && !currencies.includes(draft.currency)}
+					<option value={draft.currency}>{draft.currency}</option>
+				{/if}
+				{#each currencies as c}
+					<option value={c}>{c}</option>
+				{/each}
+			</select>
 			{#if errors.currency}<span class="error-msg">{errors.currency}</span>{/if}
 		</label>
 	</div>

--- a/src/ui/modals/LoanEditModal.svelte
+++ b/src/ui/modals/LoanEditModal.svelte
@@ -440,7 +440,14 @@
 	<div class="row">
 		<label class="field">
 			<span>Open date <em>*</em></span>
-			<input type="date" bind:value={draft.openDate} class:error={errors.openDate} />
+			<input
+				type="text"
+				inputmode="numeric"
+				placeholder="YYYY-MM-DD"
+				pattern="\d{4}-\d{2}-\d{2}"
+				bind:value={draft.openDate}
+				class:error={errors.openDate}
+			/>
 			{#if errors.openDate}<span class="error-msg">{errors.openDate}</span>{/if}
 		</label>
 
@@ -510,7 +517,14 @@
 		<div class="row">
 			<label class="field">
 				<span>Payoff date</span>
-				<input type="date" bind:value={draft.payoffDate} class:error={errors.payoffDate} />
+				<input
+					type="text"
+					inputmode="numeric"
+					placeholder="YYYY-MM-DD"
+					pattern="\d{4}-\d{2}-\d{2}"
+					bind:value={draft.payoffDate}
+					class:error={errors.payoffDate}
+				/>
 				{#if errors.payoffDate}<span class="error-msg">{errors.payoffDate}</span>{/if}
 			</label>
 

--- a/src/ui/modals/LoanEditModal.svelte
+++ b/src/ui/modals/LoanEditModal.svelte
@@ -104,12 +104,12 @@
 	let comboboxIndex: Record<ComboboxField, number> = { path: -1, funding: -1 };
 
 	function openCombobox(which: ComboboxField) {
-		comboboxOpen[which] = true;
-		comboboxIndex[which] = -1;
+		comboboxOpen = { ...comboboxOpen, [which]: true };
+		comboboxIndex = { ...comboboxIndex, [which]: -1 };
 	}
 	function closeCombobox(which: ComboboxField) {
-		comboboxOpen[which] = false;
-		comboboxIndex[which] = -1;
+		comboboxOpen = { ...comboboxOpen, [which]: false };
+		comboboxIndex = { ...comboboxIndex, [which]: -1 };
 	}
 	function suggestionsFor(which: ComboboxField): string[] {
 		const pool = which === 'path' ? pathPool : fundingPool;
@@ -143,12 +143,12 @@
 		const max = sugg.length + creatable - 1;
 		if (event.key === 'ArrowDown') {
 			event.preventDefault();
-			openCombobox(which);
-			comboboxIndex[which] = Math.min(comboboxIndex[which] + 1, max);
+			comboboxOpen = { ...comboboxOpen, [which]: true };
+			comboboxIndex = { ...comboboxIndex, [which]: Math.min(comboboxIndex[which] + 1, max) };
 		} else if (event.key === 'ArrowUp') {
 			event.preventDefault();
-			openCombobox(which);
-			comboboxIndex[which] = Math.max(comboboxIndex[which] - 1, -1);
+			comboboxOpen = { ...comboboxOpen, [which]: true };
+			comboboxIndex = { ...comboboxIndex, [which]: Math.max(comboboxIndex[which] - 1, -1) };
 		} else if (event.key === 'Enter') {
 			if (!comboboxOpen[which]) return;
 			const idx = comboboxIndex[which];
@@ -186,23 +186,33 @@
 			{#if comboboxOpen.path}
 				{@const sugg = suggestionsFor('path')}
 				{@const creatable = isCreatable('path', sugg)}
-				{#if sugg.length > 0 || creatable}
-					<ul class="combobox-list">
-						{#each sugg as s, i}
-							<li
-								class:active={comboboxIndex.path === i}
-								on:mousedown|preventDefault={() => pickSuggestion('path', s)}
-							>{s}</li>
-						{/each}
-						{#if creatable}
-							<li
-								class="combobox-create"
-								class:active={comboboxIndex.path === sugg.length}
-								on:mousedown|preventDefault={() => closeCombobox('path')}
-							>+ Create new account: <code>{draft.account}</code></li>
-						{/if}
-					</ul>
-				{/if}
+				{@const typed = (draft.account ?? '').trim()}
+				<ul class="combobox-list">
+					{#each sugg as s, i}
+						<li
+							class:active={comboboxIndex.path === i}
+							on:mousedown|preventDefault={() => pickSuggestion('path', s)}
+						>{s}</li>
+					{/each}
+					{#if creatable}
+						<li
+							class="combobox-create"
+							class:active={comboboxIndex.path === sugg.length}
+							on:mousedown|preventDefault={() => closeCombobox('path')}
+						>+ Create new account: <code>{draft.account}</code></li>
+					{/if}
+					{#if sugg.length === 0 && !creatable}
+						<li class="combobox-empty">
+							{#if typed.endsWith(':')}
+								Add a leaf segment to create a new account (e.g. <code>{typed}Visa</code>).
+							{:else if typed && !/^[A-Z][A-Za-z0-9:_-]*(:[A-Za-z0-9_-]+)+$/.test(typed)}
+								Path needs at least 2 segments — e.g. <code>Liabilities:Visa</code>.
+							{:else}
+								No matching accounts. Type a colon-separated path or pick a suggestion.
+							{/if}
+						</li>
+					{/if}
+				</ul>
 			{/if}
 			{#if errors.account}<span class="error-msg">{errors.account}</span>{/if}
 		</div>
@@ -331,23 +341,24 @@
 			{#if comboboxOpen.funding}
 				{@const sugg = suggestionsFor('funding')}
 				{@const creatable = isCreatable('funding', sugg)}
-				{#if sugg.length > 0 || creatable}
-					<ul class="combobox-list">
-						{#each sugg as s, i}
-							<li
-								class:active={comboboxIndex.funding === i}
-								on:mousedown|preventDefault={() => pickSuggestion('funding', s)}
-							>{s}</li>
-						{/each}
-						{#if creatable}
-							<li
-								class="combobox-create"
-								class:active={comboboxIndex.funding === sugg.length}
-								on:mousedown|preventDefault={() => closeCombobox('funding')}
-							>+ Use new account: <code>{draft.fundingAccount}</code></li>
-						{/if}
-					</ul>
-				{/if}
+				<ul class="combobox-list">
+					{#each sugg as s, i}
+						<li
+							class:active={comboboxIndex.funding === i}
+							on:mousedown|preventDefault={() => pickSuggestion('funding', s)}
+						>{s}</li>
+					{/each}
+					{#if creatable}
+						<li
+							class="combobox-create"
+							class:active={comboboxIndex.funding === sugg.length}
+							on:mousedown|preventDefault={() => closeCombobox('funding')}
+						>+ Use new account: <code>{draft.fundingAccount}</code></li>
+					{/if}
+					{#if sugg.length === 0 && !creatable}
+						<li class="combobox-empty">No matching accounts. Type a path or pick a suggestion.</li>
+					{/if}
+				</ul>
 			{/if}
 		</div>
 	</div>
@@ -449,6 +460,23 @@
 		padding-top: 8px;
 		margin-top: 4px;
 		font-style: italic;
+	}
+	.combobox-list .combobox-empty {
+		font-family: var(--font-interface);
+		color: var(--text-muted);
+		font-style: italic;
+		cursor: default;
+	}
+	.combobox-list .combobox-empty:hover {
+		background: transparent;
+	}
+	.combobox-list .combobox-empty code {
+		font-style: normal;
+		font-family: var(--font-monospace);
+		color: var(--text-normal);
+		background: var(--background-secondary);
+		padding: 1px 6px;
+		border-radius: 4px;
 	}
 	.combobox-list .combobox-create code {
 		font-style: normal;

--- a/src/ui/modals/LoanEditModal.svelte
+++ b/src/ui/modals/LoanEditModal.svelte
@@ -1,6 +1,6 @@
 <!-- src/ui/modals/LoanEditModal.svelte -->
 <script lang="ts">
-	import { createEventDispatcher, tick } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import type { LoanFormDraft } from '../../services/liabilities.service';
 	import { pruneDraftForMode } from '../../services/liabilities.service';
 
@@ -16,6 +16,19 @@
 		'student-loan', 'line-of-credit', 'receivable', 'other',
 	];
 
+	// Pre-baked sub-paths per loan-type. Empty when the role prefix
+	// already covers everything (e.g. receivables → Assets:Receivables:LEAF).
+	const PATH_TEMPLATES: Record<string, string[]> = {
+		'credit-card': ['Credit'],
+		'mortgage': ['Loan', 'Mortgage'],
+		'personal-loan': ['Loan', 'Personal'],
+		'auto-loan': ['Loan', 'Auto'],
+		'student-loan': ['Loan', 'Student'],
+		'line-of-credit': ['Credit', 'Line'],
+		'receivable': [],
+		'other': [],
+	};
+
 	let draft: LoanFormDraft = {
 		...initial,
 		loanType: initial.loanType ?? 'credit-card',
@@ -26,7 +39,185 @@
 	$: assetAccounts = accounts.filter(a => a.startsWith('Assets'));
 	$: incomeAccounts = accounts.filter(a => a.startsWith('Income'));
 	$: fundingPool = [...assetAccounts, ...incomeAccounts];
-	$: pathPool = accounts.filter(a => a.startsWith('Liabilities') || a.startsWith('Assets:Receivables'));
+
+	// --- Account-path segment builder state ---
+	// The role decides the locked top-level prefix that stays read-only
+	// in the UI; all editable segments live below it.
+	let prefix = 'Liabilities';
+	let segments: string[] = [];
+
+	function detectPrefix(path: string): string {
+		if (path.startsWith('Assets:Receivables:') || path === 'Assets:Receivables') return 'Assets:Receivables';
+		if (path.startsWith('Liabilities:') || path === 'Liabilities') return 'Liabilities';
+		// Fallback for free-form paths (edit mode of an arbitrary account).
+		const top = path.split(':')[0];
+		return top || 'Liabilities';
+	}
+
+	function pathToSegments(path: string, p: string): string[] {
+		if (!path || path === p) return [];
+		if (path.startsWith(p + ':')) return path.slice(p.length + 1).split(':');
+		// path doesn't sit under the prefix — surface every segment
+		return path.split(':');
+	}
+
+	onMount(() => {
+		const initialPath = (initial.account ?? '').trim();
+		prefix = detectPrefix(initialPath);
+		segments = pathToSegments(initialPath, prefix).filter(s => s.length > 0);
+		// In add mode, prefill the segments from the loan-type template
+		// when the user has nothing meaningful yet. An empty leaf gives
+		// them a place to type immediately.
+		if (mode === 'add' && segments.length === 0) {
+			const tpl = PATH_TEMPLATES[draft.loanType ?? 'other'] ?? [];
+			segments = [...tpl, ''];
+		} else if (segments.length === 0) {
+			segments = [''];
+		}
+	});
+
+	$: fullPath = [prefix, ...segments.map(s => s.trim()).filter(Boolean)].join(':');
+	$: draft.account = fullPath;
+
+	function addSegment() {
+		segments = [...segments, ''];
+	}
+
+	function removeSegment(idx: number) {
+		segments = segments.filter((_, i) => i !== idx);
+		if (segments.length === 0) segments = [''];
+	}
+
+	function setSegment(idx: number, value: string) {
+		segments = segments.map((s, i) => (i === idx ? value : s));
+	}
+
+	/**
+	 * Siblings at a given depth — the existing accounts that share the
+	 * path up to (but not including) this segment. Used to surface
+	 * "you've used these names before" chips beneath each segment input.
+	 */
+	function siblingsForSegment(idx: number): string[] {
+		const parentPath = [prefix, ...segments.slice(0, idx).map(s => s.trim()).filter(Boolean)].join(':');
+		const search = parentPath + ':';
+		const matches = accounts.filter(a => a.startsWith(search));
+		const names = matches
+			.map(a => a.slice(search.length).split(':')[0])
+			.filter(Boolean);
+		const own = (segments[idx] ?? '').trim().toLowerCase();
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const n of names) {
+			const key = n.toLowerCase();
+			if (seen.has(key)) continue;
+			if (key === own) continue; // hide the chip that matches the current value
+			seen.add(key);
+			out.push(n);
+		}
+		return out.sort().slice(0, 8);
+	}
+
+	function applyTemplate() {
+		const tpl = PATH_TEMPLATES[draft.loanType ?? 'other'] ?? [];
+		segments = [...tpl, ''];
+	}
+
+	function onLoanTypeChange() {
+		// Auto-apply the template only when the segments are all empty
+		// or match the previous template's leading entries — never clobber
+		// what the user actually typed.
+		if (mode !== 'add') return;
+		const allEmpty = segments.every(s => !s.trim());
+		if (allEmpty) {
+			const tpl = PATH_TEMPLATES[draft.loanType ?? 'other'] ?? [];
+			segments = [...tpl, ''];
+		}
+	}
+
+	const PREFIX_OPTIONS = ['Liabilities', 'Assets:Receivables'];
+	function changePrefix(value: string) {
+		prefix = value;
+	}
+
+	// --- Funding-account segment builder (same shape as the path one,
+	// but with a free top-level chosen from the user's existing accounts). ---
+
+	let fundingPrefix = 'Assets';
+	let fundingSegments: string[] = [];
+
+	$: fundingPrefixOptions = (() => {
+		const top = new Set<string>();
+		for (const a of accounts) {
+			const t = a.split(':')[0];
+			if (t) top.add(t);
+		}
+		// Always offer the conventional ones even if the vault has none yet.
+		top.add('Assets');
+		top.add('Income');
+		const arr = Array.from(top);
+		arr.sort();
+		return arr;
+	})();
+
+	function fundingPathToSegments(path: string, p: string): string[] {
+		if (!path) return [];
+		if (path.startsWith(p + ':')) return path.slice(p.length + 1).split(':');
+		if (path === p) return [];
+		// Path has a different top-level — surface every segment.
+		const parts = path.split(':');
+		fundingPrefix = parts[0];
+		return parts.slice(1);
+	}
+
+	onMount(() => {
+		const f = (initial.fundingAccount ?? '').trim();
+		if (f) {
+			fundingPrefix = f.split(':')[0];
+			fundingSegments = fundingPathToSegments(f, fundingPrefix);
+		} else {
+			fundingPrefix = 'Assets';
+			fundingSegments = [''];
+		}
+	});
+
+	$: fullFundingPath = (() => {
+		const segs = fundingSegments.map(s => s.trim()).filter(Boolean);
+		if (segs.length === 0) return '';
+		return [fundingPrefix, ...segs].join(':');
+	})();
+	$: draft.fundingAccount = fullFundingPath || null;
+
+	function addFundingSegment() {
+		fundingSegments = [...fundingSegments, ''];
+	}
+	function removeFundingSegment(idx: number) {
+		fundingSegments = fundingSegments.filter((_, i) => i !== idx);
+		if (fundingSegments.length === 0) fundingSegments = [''];
+	}
+	function setFundingSegment(idx: number, value: string) {
+		fundingSegments = fundingSegments.map((s, i) => (i === idx ? value : s));
+	}
+	function changeFundingPrefix(value: string) {
+		fundingPrefix = value;
+	}
+	function siblingsForFunding(idx: number): string[] {
+		const parentPath = [fundingPrefix, ...fundingSegments.slice(0, idx).map(s => s.trim()).filter(Boolean)].join(':');
+		const search = parentPath + ':';
+		const matches = accounts.filter(a => a.startsWith(search));
+		const names = matches
+			.map(a => a.slice(search.length).split(':')[0])
+			.filter(Boolean);
+		const own = (fundingSegments[idx] ?? '').trim().toLowerCase();
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const n of names) {
+			const key = n.toLowerCase();
+			if (seen.has(key) || key === own) continue;
+			seen.add(key);
+			out.push(n);
+		}
+		return out.sort().slice(0, 8);
+	}
 
 	function validate(): boolean {
 		errors = {};
@@ -167,53 +358,64 @@
 </script>
 
 <div class="loan-modal">
-	<!-- Account path + currency -->
+	<!-- Account path (segment builder) + currency -->
 	<div class="row">
-		<div class="field grow combobox-field">
-			<label for="loan-modal-account">Account path <em>*</em></label>
-			<input
-				id="loan-modal-account"
-				type="text"
-				placeholder="Liabilities:Credit:Visa"
-				autocomplete="off"
-				bind:value={draft.account}
-				on:focus={() => openCombobox('path')}
-				on:input={() => openCombobox('path')}
-				on:keydown={(e) => handleComboboxKey('path', e)}
-				on:blur={() => setTimeout(() => closeCombobox('path'), 120)}
-				class:error={errors.account}
-			/>
-			{#if comboboxOpen.path}
-				{@const sugg = suggestionsFor('path')}
-				{@const creatable = isCreatable('path', sugg)}
-				{@const typed = (draft.account ?? '').trim()}
-				<ul class="combobox-list">
-					{#each sugg as s, i}
-						<li
-							class:active={comboboxIndex.path === i}
-							on:mousedown|preventDefault={() => pickSuggestion('path', s)}
-						>{s}</li>
+		<div class="field grow path-builder-field">
+			<label class="field-label">Account path <em>*</em></label>
+			<div class="segments-row" role="group" aria-label="Account path segments">
+				<select
+					class="prefix-select"
+					value={prefix}
+					on:change={(e) => changePrefix(e.currentTarget.value)}
+					title="Top-level role of this account"
+				>
+					{#if !PREFIX_OPTIONS.includes(prefix)}
+						<option value={prefix}>{prefix}</option>
+					{/if}
+					{#each PREFIX_OPTIONS as p}
+						<option value={p}>{p}</option>
 					{/each}
-					{#if creatable}
-						<li
-							class="combobox-create"
-							class:active={comboboxIndex.path === sugg.length}
-							on:mousedown|preventDefault={() => closeCombobox('path')}
-						>+ Create new account: <code>{draft.account}</code></li>
-					{/if}
-					{#if sugg.length === 0 && !creatable}
-						<li class="combobox-empty">
-							{#if typed.endsWith(':')}
-								Add a leaf segment to create a new account (e.g. <code>{typed}Visa</code>).
-							{:else if typed && !/^[A-Z][A-Za-z0-9:_-]*(:[A-Za-z0-9_-]+)+$/.test(typed)}
-								Path needs at least 2 segments — e.g. <code>Liabilities:Visa</code>.
-							{:else}
-								No matching accounts. Type a colon-separated path or pick a suggestion.
-							{/if}
-						</li>
-					{/if}
-				</ul>
-			{/if}
+				</select>
+				{#each segments as seg, idx}
+					<span class="segment-sep">:</span>
+					<div class="segment">
+						<input
+							type="text"
+							class="segment-input"
+							placeholder={idx === 0 ? 'Credit' : (idx === segments.length - 1 ? 'Visa' : 'segment')}
+							value={seg}
+							on:input={(e) => setSegment(idx, e.currentTarget.value)}
+						/>
+						{#if segments.length > 1}
+							<button class="segment-remove" type="button" on:click={() => removeSegment(idx)} title="Remove this segment">×</button>
+						{/if}
+					</div>
+				{/each}
+				<button class="segment-add" type="button" on:click={addSegment} title="Add another segment">+</button>
+			</div>
+
+			<!-- Sibling chips: existing names at each depth that the user can pick with one click. -->
+			{#each segments as seg, idx}
+				{@const sib = siblingsForSegment(idx)}
+				{#if sib.length > 0}
+					<div class="sibling-chips">
+						<span class="chips-label">depth {idx + 1}:</span>
+						{#each sib as s}
+							<button class="chip" type="button" on:click={() => setSegment(idx, s)}>{s}</button>
+						{/each}
+					</div>
+				{/if}
+			{/each}
+
+			<!-- Live full-path preview + advanced edit-as-text toggle. -->
+			<div class="path-preview">
+				<span class="preview-label">Full path:</span>
+				<code class:error={!!errors.account}>{fullPath || '—'}</code>
+				{#if mode === 'add' && draft.loanType && (PATH_TEMPLATES[draft.loanType]?.length ?? 0) > 0}
+					<button class="link-btn" type="button" on:click={applyTemplate} title="Reset segments to the loan-type's template">↻ template</button>
+				{/if}
+			</div>
+
 			{#if errors.account}<span class="error-msg">{errors.account}</span>{/if}
 		</div>
 
@@ -244,7 +446,7 @@
 
 		<label class="field">
 			<span>Loan type</span>
-			<select bind:value={draft.loanType}>
+			<select bind:value={draft.loanType} on:change={onLoanTypeChange}>
 				{#each LOAN_TYPES as t}<option value={t}>{t}</option>{/each}
 			</select>
 		</label>
@@ -320,46 +522,61 @@
 		</div>
 	{/if}
 
-	<!-- Funding account -->
+	<!-- Funding account (segment builder) -->
 	<div class="row">
-		<div class="field grow combobox-field">
-			<label for="loan-modal-funding">
+		<div class="field grow path-builder-field">
+			<label class="field-label">
 				Funding account
 				<span class="muted small">— used by the recurring widget when synthesising payment rules</span>
 			</label>
-			<input
-				id="loan-modal-funding"
-				type="text"
-				placeholder="Assets:Banking:… or Income:Repayment"
-				autocomplete="off"
-				bind:value={draft.fundingAccount}
-				on:focus={() => openCombobox('funding')}
-				on:input={() => openCombobox('funding')}
-				on:keydown={(e) => handleComboboxKey('funding', e)}
-				on:blur={() => setTimeout(() => closeCombobox('funding'), 120)}
-			/>
-			{#if comboboxOpen.funding}
-				{@const sugg = suggestionsFor('funding')}
-				{@const creatable = isCreatable('funding', sugg)}
-				<ul class="combobox-list">
-					{#each sugg as s, i}
-						<li
-							class:active={comboboxIndex.funding === i}
-							on:mousedown|preventDefault={() => pickSuggestion('funding', s)}
-						>{s}</li>
+			<div class="segments-row" role="group" aria-label="Funding account segments">
+				<select
+					class="prefix-select"
+					value={fundingPrefix}
+					on:change={(e) => changeFundingPrefix(e.currentTarget.value)}
+					title="Top-level role of the funding account"
+				>
+					{#if !fundingPrefixOptions.includes(fundingPrefix)}
+						<option value={fundingPrefix}>{fundingPrefix}</option>
+					{/if}
+					{#each fundingPrefixOptions as p}
+						<option value={p}>{p}</option>
 					{/each}
-					{#if creatable}
-						<li
-							class="combobox-create"
-							class:active={comboboxIndex.funding === sugg.length}
-							on:mousedown|preventDefault={() => closeCombobox('funding')}
-						>+ Use new account: <code>{draft.fundingAccount}</code></li>
-					{/if}
-					{#if sugg.length === 0 && !creatable}
-						<li class="combobox-empty">No matching accounts. Type a path or pick a suggestion.</li>
-					{/if}
-				</ul>
-			{/if}
+				</select>
+				{#each fundingSegments as seg, idx}
+					<span class="segment-sep">:</span>
+					<div class="segment">
+						<input
+							type="text"
+							class="segment-input"
+							placeholder={idx === 0 ? 'Banking' : (idx === fundingSegments.length - 1 ? 'leaf' : 'segment')}
+							value={seg}
+							on:input={(e) => setFundingSegment(idx, e.currentTarget.value)}
+						/>
+						{#if fundingSegments.length > 1}
+							<button class="segment-remove" type="button" on:click={() => removeFundingSegment(idx)} title="Remove this segment">×</button>
+						{/if}
+					</div>
+				{/each}
+				<button class="segment-add" type="button" on:click={addFundingSegment} title="Add another segment">+</button>
+			</div>
+
+			{#each fundingSegments as seg, idx}
+				{@const sib = siblingsForFunding(idx)}
+				{#if sib.length > 0}
+					<div class="sibling-chips">
+						<span class="chips-label">depth {idx + 1}:</span>
+						{#each sib as s}
+							<button class="chip" type="button" on:click={() => setFundingSegment(idx, s)}>{s}</button>
+						{/each}
+					</div>
+				{/if}
+			{/each}
+
+			<div class="path-preview">
+				<span class="preview-label">Full path:</span>
+				<code>{fullFundingPath || '(none)'}</code>
+			</div>
 		</div>
 	</div>
 
@@ -422,7 +639,149 @@
 		font-size: var(--font-ui-smaller);
 	}
 
-	/* Combobox: wraps an input + an absolutely-positioned suggestion list. */
+	/* Account-path / funding segment builder */
+	.path-builder-field {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.field-label {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+	.segments-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 6px;
+		background: var(--background-secondary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+	}
+	.prefix-select {
+		padding: 4px 6px;
+		border-radius: var(--radius-s);
+		border: 1px solid var(--background-modifier-border);
+		background: var(--background-primary);
+		color: var(--text-accent);
+		font-family: var(--font-monospace);
+		font-size: var(--font-ui-small);
+		font-weight: 600;
+	}
+	.segment-sep {
+		color: var(--text-muted);
+		font-family: var(--font-monospace);
+		font-weight: 600;
+		padding: 0 2px;
+	}
+	.segment {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		padding: 0 4px;
+		flex: 0 1 auto;
+	}
+	.segment-input {
+		border: none !important;
+		padding: 4px 6px !important;
+		min-width: 80px;
+		max-width: 160px;
+		font-family: var(--font-monospace);
+		background: transparent;
+	}
+	.segment-input:focus {
+		outline: none;
+	}
+	.segment-remove,
+	.segment-add {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 2px 6px;
+		border-radius: 4px;
+		font-size: var(--font-ui-small);
+		font-weight: 600;
+		line-height: 1;
+	}
+	.segment-remove:hover {
+		color: var(--color-red);
+		background: color-mix(in srgb, var(--color-red), transparent 90%);
+	}
+	.segment-add {
+		padding: 4px 10px;
+		border: 1px dashed var(--background-modifier-border-hover);
+		color: var(--text-muted);
+	}
+	.segment-add:hover {
+		border-color: var(--interactive-accent);
+		color: var(--interactive-accent);
+	}
+
+	.sibling-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		align-items: center;
+		font-size: var(--font-ui-smaller);
+	}
+	.chips-label {
+		color: var(--text-muted);
+		font-family: var(--font-monospace);
+		margin-right: 4px;
+	}
+	.chip {
+		padding: 2px 8px;
+		border-radius: 999px;
+		border: 1px solid var(--background-modifier-border);
+		background: var(--background-primary);
+		color: var(--text-normal);
+		cursor: pointer;
+		font-family: var(--font-monospace);
+		font-size: 11px;
+	}
+	.chip:hover {
+		border-color: var(--interactive-accent);
+		color: var(--interactive-accent);
+	}
+
+	.path-preview {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+		font-size: var(--font-ui-smaller);
+	}
+	.preview-label {
+		color: var(--text-muted);
+	}
+	.path-preview code {
+		font-family: var(--font-monospace);
+		color: var(--text-normal);
+		background: var(--background-secondary);
+		padding: 2px 8px;
+		border-radius: 4px;
+	}
+	.path-preview code.error {
+		color: var(--color-red);
+	}
+	.link-btn {
+		background: transparent;
+		border: none;
+		color: var(--interactive-accent);
+		cursor: pointer;
+		font-size: var(--font-ui-smaller);
+		padding: 0;
+	}
+	.link-btn:hover {
+		text-decoration: underline;
+	}
+
+	/* Legacy combobox styles (kept for fallback / not used by current template). */
 	.combobox-field {
 		position: relative;
 	}

--- a/src/ui/modals/LoanEditModal.svelte
+++ b/src/ui/modals/LoanEditModal.svelte
@@ -1,7 +1,8 @@
 <!-- src/ui/modals/LoanEditModal.svelte -->
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, tick } from 'svelte';
 	import type { LoanFormDraft } from '../../services/liabilities.service';
+	import { pruneDraftForMode } from '../../services/liabilities.service';
 
 	export let initial: LoanFormDraft;
 	export let mode: 'add' | 'edit' = 'add';
@@ -15,18 +16,24 @@
 		'student-loan', 'line-of-credit', 'receivable', 'other',
 	];
 
-	let draft: LoanFormDraft = { ...initial, loanType: initial.loanType ?? 'credit-card' };
+	let draft: LoanFormDraft = {
+		...initial,
+		loanType: initial.loanType ?? 'credit-card',
+		paymentMode: initial.paymentMode ?? 'recurring',
+	};
 	let errors: Record<string, string> = {};
 
 	$: assetAccounts = accounts.filter(a => a.startsWith('Assets'));
 	$: incomeAccounts = accounts.filter(a => a.startsWith('Income'));
-	$: fundingAccounts = [...assetAccounts, ...incomeAccounts];
+	$: fundingPool = [...assetAccounts, ...incomeAccounts];
+	$: pathPool = accounts.filter(a => a.startsWith('Liabilities') || a.startsWith('Assets:Receivables'));
 
 	function validate(): boolean {
 		errors = {};
 		const path = (draft.account ?? '').trim();
 		if (!path) errors.account = 'Account path is required';
-		else if (!/^[A-Z][A-Za-z0-9:_-]*$/.test(path)) errors.account = 'Format: \'TopLevel:Sub:Leaf\' (must start with capital)';
+		else if (!/^[A-Z][A-Za-z0-9:_-]*(:[A-Za-z0-9_-]+)+$/.test(path))
+			errors.account = "Use at least 2 segments (e.g. 'Liabilities:Visa')";
 
 		const ccy = (draft.currency ?? '').trim();
 		if (!ccy) errors.currency = 'Currency is required';
@@ -34,21 +41,27 @@
 
 		if (!/^\d{4}-\d{2}-\d{2}$/.test((draft.openDate ?? '').trim())) errors.openDate = 'Must be YYYY-MM-DD';
 
-		if (draft.dueDay !== null && (draft.dueDay < 1 || draft.dueDay > 31))
-			errors.dueDay = 'Day must be 1–31';
-		if (draft.principal !== null && draft.principal < 0)
-			errors.principal = 'Must be ≥ 0';
-		if (draft.monthlyPayment !== null && draft.monthlyPayment < 0)
-			errors.monthlyPayment = 'Must be ≥ 0';
-		if (draft.interestRate !== null && draft.interestRate < 0)
-			errors.interestRate = 'Must be ≥ 0';
+		if (draft.principal !== null && draft.principal < 0) errors.principal = 'Must be ≥ 0';
+		if (draft.interestRate !== null && draft.interestRate < 0) errors.interestRate = 'Must be ≥ 0';
+
+		if (draft.paymentMode === 'recurring') {
+			if (draft.dueDay !== null && (draft.dueDay < 1 || draft.dueDay > 31))
+				errors.dueDay = 'Day must be 1–31';
+			if (draft.monthlyPayment !== null && draft.monthlyPayment < 0)
+				errors.monthlyPayment = 'Must be ≥ 0';
+		} else {
+			if (draft.payoffDate && !/^\d{4}-\d{2}-\d{2}$/.test(draft.payoffDate.trim()))
+				errors.payoffDate = 'Must be YYYY-MM-DD';
+			if (draft.payoffAmount !== null && draft.payoffAmount < 0)
+				errors.payoffAmount = 'Must be ≥ 0';
+		}
 
 		return Object.keys(errors).length === 0;
 	}
 
 	function handleSave() {
 		if (!validate()) return;
-		const cleaned: LoanFormDraft = {
+		const cleanedRaw: LoanFormDraft = {
 			account: draft.account.trim(),
 			currency: draft.currency.trim().toUpperCase(),
 			openDate: draft.openDate.trim(),
@@ -59,7 +72,11 @@
 			monthlyPayment: numberOrNull(draft.monthlyPayment),
 			dueDay: draft.dueDay !== null && draft.dueDay !== undefined ? Math.round(Number(draft.dueDay)) : null,
 			fundingAccount: (draft.fundingAccount ?? '').trim() || null,
+			paymentMode: draft.paymentMode,
+			payoffDate: (draft.payoffDate ?? '').trim() || null,
+			payoffAmount: numberOrNull(draft.payoffAmount),
 		};
+		const cleaned = pruneDraftForMode(cleanedRaw);
 		dispatch('save', { draft: cleaned, originalAccount: initial.account });
 	}
 
@@ -78,26 +95,117 @@
 		if (!confirm(`Remove loan account "${initial.account}"?\n\nThe open directive and metadata will be deleted from accounts.beancount. Past transactions referencing the account stay intact.`)) return;
 		dispatch('delete', { originalAccount: initial.account });
 	}
+
+	// --- Reusable inline combobox state. We keep two so the path and
+	// funding fields can each have their own open/highlight cursor. ---
+
+	type ComboboxField = 'path' | 'funding';
+	let comboboxOpen: Record<ComboboxField, boolean> = { path: false, funding: false };
+	let comboboxIndex: Record<ComboboxField, number> = { path: -1, funding: -1 };
+
+	function openCombobox(which: ComboboxField) {
+		comboboxOpen[which] = true;
+		comboboxIndex[which] = -1;
+	}
+	function closeCombobox(which: ComboboxField) {
+		comboboxOpen[which] = false;
+		comboboxIndex[which] = -1;
+	}
+	function suggestionsFor(which: ComboboxField): string[] {
+		const pool = which === 'path' ? pathPool : fundingPool;
+		const value = which === 'path' ? draft.account : (draft.fundingAccount ?? '');
+		const q = (value ?? '').trim().toLowerCase();
+		if (!q) return pool.slice(0, 12);
+		return pool
+			.filter(a => a.toLowerCase().includes(q))
+			.slice(0, 12);
+	}
+	function pickSuggestion(which: ComboboxField, value: string) {
+		if (which === 'path') {
+			draft.account = value;
+		} else {
+			draft.fundingAccount = value;
+		}
+		closeCombobox(which);
+	}
+	function isCreatable(which: ComboboxField, suggestions: string[]): boolean {
+		const value = which === 'path' ? draft.account : (draft.fundingAccount ?? '');
+		const v = (value ?? '').trim();
+		if (!v) return false;
+		if (which === 'path' && !/^[A-Z][A-Za-z0-9:_-]*(:[A-Za-z0-9_-]+)+$/.test(v)) return false;
+		if (which === 'funding' && !/^[A-Z][A-Za-z0-9:_-]*$/.test(v)) return false;
+		// Don't show "create new" when the typed value matches an existing entry.
+		return !suggestions.some(s => s === v);
+	}
+	async function handleComboboxKey(which: ComboboxField, event: KeyboardEvent) {
+		const sugg = suggestionsFor(which);
+		const creatable = isCreatable(which, sugg) ? 1 : 0;
+		const max = sugg.length + creatable - 1;
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			openCombobox(which);
+			comboboxIndex[which] = Math.min(comboboxIndex[which] + 1, max);
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			openCombobox(which);
+			comboboxIndex[which] = Math.max(comboboxIndex[which] - 1, -1);
+		} else if (event.key === 'Enter') {
+			if (!comboboxOpen[which]) return;
+			const idx = comboboxIndex[which];
+			if (idx >= 0 && idx < sugg.length) {
+				event.preventDefault();
+				pickSuggestion(which, sugg[idx]);
+			} else if (idx === sugg.length && creatable) {
+				// "Create new" row — accept the typed value as-is.
+				event.preventDefault();
+				closeCombobox(which);
+			}
+		} else if (event.key === 'Escape') {
+			closeCombobox(which);
+		}
+	}
 </script>
 
 <div class="loan-modal">
+	<!-- Account path + currency -->
 	<div class="row">
-		<label class="field grow">
-			<span>Account path <em>*</em></span>
+		<div class="field grow combobox-field">
+			<label for="loan-modal-account">Account path <em>*</em></label>
 			<input
+				id="loan-modal-account"
 				type="text"
 				placeholder="Liabilities:Credit:Visa"
-				list="loan-accounts"
+				autocomplete="off"
 				bind:value={draft.account}
+				on:focus={() => openCombobox('path')}
+				on:input={() => openCombobox('path')}
+				on:keydown={(e) => handleComboboxKey('path', e)}
+				on:blur={() => setTimeout(() => closeCombobox('path'), 120)}
 				class:error={errors.account}
 			/>
-			<datalist id="loan-accounts">
-				{#each accounts.filter(a => a.startsWith('Liabilities') || a.startsWith('Assets:Receivables')) as a}
-					<option value={a} />
-				{/each}
-			</datalist>
+			{#if comboboxOpen.path}
+				{@const sugg = suggestionsFor('path')}
+				{@const creatable = isCreatable('path', sugg)}
+				{#if sugg.length > 0 || creatable}
+					<ul class="combobox-list">
+						{#each sugg as s, i}
+							<li
+								class:active={comboboxIndex.path === i}
+								on:mousedown|preventDefault={() => pickSuggestion('path', s)}
+							>{s}</li>
+						{/each}
+						{#if creatable}
+							<li
+								class="combobox-create"
+								class:active={comboboxIndex.path === sugg.length}
+								on:mousedown|preventDefault={() => closeCombobox('path')}
+							>+ Create new account: <code>{draft.account}</code></li>
+						{/if}
+					</ul>
+				{/if}
+			{/if}
 			{#if errors.account}<span class="error-msg">{errors.account}</span>{/if}
-		</label>
+		</div>
 
 		<label class="field narrow">
 			<span>Currency <em>*</em></span>
@@ -116,14 +224,11 @@
 		</label>
 	</div>
 
+	<!-- Identity row -->
 	<div class="row">
 		<label class="field">
 			<span>Open date <em>*</em></span>
-			<input
-				type="date"
-				bind:value={draft.openDate}
-				class:error={errors.openDate}
-			/>
+			<input type="date" bind:value={draft.openDate} class:error={errors.openDate} />
 			{#if errors.openDate}<span class="error-msg">{errors.openDate}</span>{/if}
 		</label>
 
@@ -136,78 +241,115 @@
 
 		<label class="field grow">
 			<span>Counterparty</span>
-			<input
-				type="text"
-				placeholder="Banco Santander, Maria Esther, …"
-				bind:value={draft.counterparty}
-			/>
+			<input type="text" placeholder="Banco Santander, Maria Esther, …" bind:value={draft.counterparty} />
 		</label>
 	</div>
 
+	<!-- Headline numbers (apply to both modes) -->
 	<div class="row">
 		<label class="field">
 			<span>Principal</span>
-			<input
-				type="number"
-				step="any"
-				placeholder="0"
-				bind:value={draft.principal}
-				class:error={errors.principal}
-			/>
+			<input type="number" step="any" placeholder="0" bind:value={draft.principal} class:error={errors.principal} />
 			{#if errors.principal}<span class="error-msg">{errors.principal}</span>{/if}
 		</label>
 
 		<label class="field">
 			<span>Interest rate (% APR)</span>
-			<input
-				type="number"
-				step="any"
-				placeholder="0"
-				bind:value={draft.interestRate}
-				class:error={errors.interestRate}
-			/>
+			<input type="number" step="any" placeholder="0" bind:value={draft.interestRate} class:error={errors.interestRate} />
 			{#if errors.interestRate}<span class="error-msg">{errors.interestRate}</span>{/if}
-		</label>
-
-		<label class="field">
-			<span>Monthly payment</span>
-			<input
-				type="number"
-				step="any"
-				placeholder="0"
-				bind:value={draft.monthlyPayment}
-				class:error={errors.monthlyPayment}
-			/>
-			{#if errors.monthlyPayment}<span class="error-msg">{errors.monthlyPayment}</span>{/if}
-		</label>
-
-		<label class="field narrow">
-			<span>Due day</span>
-			<input
-				type="number"
-				min="1"
-				max="31"
-				placeholder="1–31"
-				bind:value={draft.dueDay}
-				class:error={errors.dueDay}
-			/>
-			{#if errors.dueDay}<span class="error-msg">{errors.dueDay}</span>{/if}
 		</label>
 	</div>
 
-	<div class="row">
-		<label class="field grow">
-			<span>Funding account (used by the recurring widget when synthesising payment rules)</span>
-			<input
-				type="text"
-				list="loan-funding"
-				placeholder="Assets:Banking:… or Income:Repayment"
-				bind:value={draft.fundingAccount}
-			/>
-			<datalist id="loan-funding">
-				{#each fundingAccounts as a}<option value={a} />{/each}
-			</datalist>
+	<!-- Payment schedule selector -->
+	<fieldset class="payment-mode">
+		<legend>Payment schedule</legend>
+		<label class="radio">
+			<input type="radio" bind:group={draft.paymentMode} value="recurring" />
+			<span>
+				<strong>Recurring monthly</strong>
+				<span class="hint">a fixed amount every month on the same day</span>
+			</span>
 		</label>
+		<label class="radio">
+			<input type="radio" bind:group={draft.paymentMode} value="one-time" />
+			<span>
+				<strong>One-time payoff</strong>
+				<span class="hint">a single lump-sum payment by a target date</span>
+			</span>
+		</label>
+	</fieldset>
+
+	<!-- Mode-specific fields -->
+	{#if draft.paymentMode === 'recurring'}
+		<div class="row">
+			<label class="field">
+				<span>Monthly payment</span>
+				<input type="number" step="any" placeholder="0" bind:value={draft.monthlyPayment} class:error={errors.monthlyPayment} />
+				{#if errors.monthlyPayment}<span class="error-msg">{errors.monthlyPayment}</span>{/if}
+			</label>
+
+			<label class="field narrow">
+				<span>Due day</span>
+				<input type="number" min="1" max="31" placeholder="1–31" bind:value={draft.dueDay} class:error={errors.dueDay} />
+				{#if errors.dueDay}<span class="error-msg">{errors.dueDay}</span>{/if}
+			</label>
+		</div>
+	{:else}
+		<div class="row">
+			<label class="field">
+				<span>Payoff date</span>
+				<input type="date" bind:value={draft.payoffDate} class:error={errors.payoffDate} />
+				{#if errors.payoffDate}<span class="error-msg">{errors.payoffDate}</span>{/if}
+			</label>
+
+			<label class="field">
+				<span>Payoff amount</span>
+				<input type="number" step="any" placeholder="0" bind:value={draft.payoffAmount} class:error={errors.payoffAmount} />
+				{#if errors.payoffAmount}<span class="error-msg">{errors.payoffAmount}</span>{/if}
+			</label>
+		</div>
+	{/if}
+
+	<!-- Funding account -->
+	<div class="row">
+		<div class="field grow combobox-field">
+			<label for="loan-modal-funding">
+				Funding account
+				<span class="muted small">— used by the recurring widget when synthesising payment rules</span>
+			</label>
+			<input
+				id="loan-modal-funding"
+				type="text"
+				placeholder="Assets:Banking:… or Income:Repayment"
+				autocomplete="off"
+				bind:value={draft.fundingAccount}
+				on:focus={() => openCombobox('funding')}
+				on:input={() => openCombobox('funding')}
+				on:keydown={(e) => handleComboboxKey('funding', e)}
+				on:blur={() => setTimeout(() => closeCombobox('funding'), 120)}
+			/>
+			{#if comboboxOpen.funding}
+				{@const sugg = suggestionsFor('funding')}
+				{@const creatable = isCreatable('funding', sugg)}
+				{#if sugg.length > 0 || creatable}
+					<ul class="combobox-list">
+						{#each sugg as s, i}
+							<li
+								class:active={comboboxIndex.funding === i}
+								on:mousedown|preventDefault={() => pickSuggestion('funding', s)}
+							>{s}</li>
+						{/each}
+						{#if creatable}
+							<li
+								class="combobox-create"
+								class:active={comboboxIndex.funding === sugg.length}
+								on:mousedown|preventDefault={() => closeCombobox('funding')}
+							>+ Use new account: <code>{draft.fundingAccount}</code></li>
+						{/if}
+					</ul>
+				{/if}
+			{/if}
+		</div>
 	</div>
 
 	<div class="footer">
@@ -240,7 +382,8 @@
 	}
 	.field.grow { flex: 1 1 240px; }
 	.field.narrow { flex: 0 0 120px; }
-	.field span {
+	.field > label,
+	.field > span {
 		font-size: var(--font-ui-small);
 		color: var(--text-muted);
 	}
@@ -248,6 +391,8 @@
 		color: var(--color-red);
 		font-style: normal;
 	}
+	.muted { color: var(--text-faint); }
+	.small { font-size: var(--font-ui-smaller); }
 	.field input,
 	.field select {
 		width: 100%;
@@ -264,6 +409,90 @@
 	.error-msg {
 		color: var(--color-red);
 		font-size: var(--font-ui-smaller);
+	}
+
+	/* Combobox: wraps an input + an absolutely-positioned suggestion list. */
+	.combobox-field {
+		position: relative;
+	}
+	.combobox-list {
+		position: absolute;
+		top: calc(100% + 2px);
+		left: 0;
+		right: 0;
+		max-height: 240px;
+		overflow-y: auto;
+		margin: 0;
+		padding: 4px 0;
+		list-style: none;
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		box-shadow: var(--shadow-s);
+		z-index: 50;
+	}
+	.combobox-list li {
+		padding: 6px 10px;
+		cursor: pointer;
+		font-family: var(--font-monospace);
+		font-size: var(--font-ui-small);
+		color: var(--text-normal);
+	}
+	.combobox-list li:hover,
+	.combobox-list li.active {
+		background: var(--background-modifier-hover);
+	}
+	.combobox-list .combobox-create {
+		font-family: var(--font-interface);
+		color: var(--interactive-accent);
+		border-top: 1px solid var(--background-modifier-border);
+		padding-top: 8px;
+		margin-top: 4px;
+		font-style: italic;
+	}
+	.combobox-list .combobox-create code {
+		font-style: normal;
+		font-family: var(--font-monospace);
+		color: var(--text-normal);
+		background: var(--background-secondary);
+		padding: 1px 6px;
+		border-radius: 4px;
+		margin-left: 4px;
+	}
+
+	/* Payment-mode fieldset */
+	.payment-mode {
+		margin: 0;
+		padding: var(--size-4-3);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-s);
+		background: var(--background-secondary);
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	.payment-mode legend {
+		padding: 0 6px;
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+	.payment-mode .radio {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		cursor: pointer;
+	}
+	.payment-mode .radio input { margin-top: 4px; }
+	.payment-mode .radio strong {
+		display: block;
+		font-weight: 600;
+		font-size: var(--font-ui-small);
+		color: var(--text-normal);
+	}
+	.payment-mode .radio .hint {
+		display: block;
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
 	}
 
 	.footer {

--- a/src/ui/modals/LoanEditModal.ts
+++ b/src/ui/modals/LoanEditModal.ts
@@ -8,7 +8,7 @@ import {
     applyLoanEdits,
     type LoanFormDraft,
 } from '../../services/liabilities.service';
-import { getOpenAccounts } from '../../utils/accounts';
+import { getOpenAccounts, getCommodities } from '../../utils/accounts';
 import { getAllCurrenciesQuery } from '../../queries/index';
 import { parse as parseCsv } from 'csv-parse/sync';
 import { Logger } from '../../utils/logger';
@@ -49,18 +49,40 @@ export class LoanEditModal extends Modal {
         let accounts: string[] = [];
         let currencies: string[] = [this.plugin.settings.operatingCurrency || 'USD'];
         try {
-            const [accs, csv] = await Promise.all([
+            // Two sources, unioned: `#commodities` covers every declared
+            // commodity (canonical list — includes assets like BTC/XAU
+            // that have no postings yet); `distinct(currency)` from
+            // postings catches anything actually transacted.
+            const [accs, declaredCommodities, postingsCsv] = await Promise.all([
                 getOpenAccounts(this.plugin),
+                getCommodities(this.plugin).catch(() => [] as Array<{ name: string }>),
                 this.plugin.runQuery(getAllCurrenciesQuery()).catch(() => ''),
             ]);
             accounts = accs ?? [];
-            if (csv) {
-                const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
-                const fetched = rows.map((r: any) => r['currency_']).filter(Boolean) as string[];
-                if (fetched.length > 0) currencies = Array.from(new Set(fetched));
+
+            const merged = new Set<string>();
+            for (const c of declaredCommodities ?? []) {
+                if (c?.name) merged.add(c.name);
+            }
+            if (postingsCsv) {
+                const rows = parseCsv(postingsCsv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+                for (const r of rows) {
+                    const code = (r['currency_'] ?? '').trim();
+                    if (code) merged.add(code);
+                }
             }
             const op = this.plugin.settings.operatingCurrency;
-            if (op && !currencies.includes(op)) currencies.unshift(op);
+            if (op) merged.add(op);
+
+            // Operating currency floats to the top, rest sorted alphabetically.
+            const sorted = Array.from(merged).sort((a, b) => {
+                if (op) {
+                    if (a === op) return -1;
+                    if (b === op) return 1;
+                }
+                return a.localeCompare(b);
+            });
+            if (sorted.length > 0) currencies = sorted;
         } catch (e) {
             Logger.log('[LoanEditModal] Could not prefetch accounts/currencies:', e);
         }

--- a/src/ui/modals/LoanEditModal.ts
+++ b/src/ui/modals/LoanEditModal.ts
@@ -1,0 +1,146 @@
+// src/ui/modals/LoanEditModal.ts
+
+import { App, Modal, Notice } from 'obsidian';
+import type BeancountPlugin from '../../main';
+import LoanEditModalComponent from './LoanEditModal.svelte';
+import {
+    parseLoanAccounts,
+    applyLoanEdits,
+    type LoanFormDraft,
+} from '../../services/liabilities.service';
+import { getOpenAccounts } from '../../utils/accounts';
+import { getAllCurrenciesQuery } from '../../queries/index';
+import { parse as parseCsv } from 'csv-parse/sync';
+import { Logger } from '../../utils/logger';
+
+type Mode = 'add' | 'edit';
+
+export class LoanEditModal extends Modal {
+    plugin: BeancountPlugin;
+    private component: any;
+    private mode: Mode;
+    private initial: LoanFormDraft;
+    private onSaved?: () => void;
+
+    constructor(
+        app: App,
+        plugin: BeancountPlugin,
+        opts: { mode: Mode; initial: LoanFormDraft; onSaved?: () => void },
+    ) {
+        super(app);
+        this.plugin = plugin;
+        this.mode = opts.mode;
+        this.initial = opts.initial;
+        this.onSaved = opts.onSaved;
+    }
+
+    private resolveAccountsPath(): string {
+        const folder = this.plugin.settings.structuredFolderName?.trim() || 'Finances';
+        return `${folder}/accounts.beancount`;
+    }
+
+    async onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.style.maxWidth = '720px';
+        this.modalEl.style.width = '90vw';
+        this.setTitle(this.mode === 'add' ? 'Add loan account' : `Edit ${this.initial.account}`);
+
+        let accounts: string[] = [];
+        let currencies: string[] = [this.plugin.settings.operatingCurrency || 'USD'];
+        try {
+            const [accs, csv] = await Promise.all([
+                getOpenAccounts(this.plugin),
+                this.plugin.runQuery(getAllCurrenciesQuery()).catch(() => ''),
+            ]);
+            accounts = accs ?? [];
+            if (csv) {
+                const rows = parseCsv(csv, { columns: true, skip_empty_lines: true, trim: true }) as any[];
+                const fetched = rows.map((r: any) => r['currency_']).filter(Boolean) as string[];
+                if (fetched.length > 0) currencies = Array.from(new Set(fetched));
+            }
+            const op = this.plugin.settings.operatingCurrency;
+            if (op && !currencies.includes(op)) currencies.unshift(op);
+        } catch (e) {
+            Logger.log('[LoanEditModal] Could not prefetch accounts/currencies:', e);
+        }
+
+        this.component = new (LoanEditModalComponent as any)({
+            target: contentEl,
+            props: {
+                initial: this.initial,
+                mode: this.mode,
+                accounts,
+                currencies,
+            },
+        });
+
+        this.component.$on('save', async (e: any) => {
+            const { draft, originalAccount } = e.detail as { draft: LoanFormDraft; originalAccount: string };
+            try {
+                await this.persist(draft, originalAccount);
+                new Notice(`Loan account ${this.mode === 'add' ? 'added' : 'updated'}.`);
+                this.close();
+                this.onSaved?.();
+            } catch (err) {
+                new Notice(`Failed to save: ${err instanceof Error ? err.message : String(err)}`);
+                Logger.error('[LoanEditModal] persist error:', err);
+            }
+        });
+
+        this.component.$on('delete', async (e: any) => {
+            const { originalAccount } = e.detail as { originalAccount: string };
+            try {
+                await this.persistDelete(originalAccount);
+                new Notice(`Loan account "${originalAccount}" removed.`);
+                this.close();
+                this.onSaved?.();
+            } catch (err) {
+                new Notice(`Failed to delete: ${err instanceof Error ? err.message : String(err)}`);
+                Logger.error('[LoanEditModal] delete error:', err);
+            }
+        });
+
+        this.component.$on('cancel', () => this.close());
+    }
+
+    private async persist(draft: LoanFormDraft, originalAccount: string): Promise<void> {
+        const path = this.resolveAccountsPath();
+        const adapter = this.plugin.app.vault.adapter;
+        const exists = await adapter.exists(path);
+        const original = exists ? await adapter.read(path) : '';
+
+        if (this.mode === 'add') {
+            const existing = parseLoanAccounts(original);
+            if (existing.some(a => a.account === draft.account)) {
+                throw new Error(`Account "${draft.account}" already exists.`);
+            }
+            const next = applyLoanEdits(original, {}, [draft]);
+            await adapter.write(path, next);
+            return;
+        }
+
+        // edit: rewrite the original block in place. If the user changed
+        // the account path we treat it as a rename — same surgical edit
+        // since we key by `originalAccount`.
+        const next = applyLoanEdits(original, { [originalAccount]: draft }, []);
+        await adapter.write(path, next);
+    }
+
+    private async persistDelete(originalAccount: string): Promise<void> {
+        const path = this.resolveAccountsPath();
+        const adapter = this.plugin.app.vault.adapter;
+        const exists = await adapter.exists(path);
+        if (!exists) return;
+        const original = await adapter.read(path);
+        const next = applyLoanEdits(original, { [originalAccount]: null }, []);
+        await adapter.write(path, next);
+    }
+
+    onClose() {
+        if (this.component) {
+            this.component.$destroy();
+            this.component = null;
+        }
+    }
+}

--- a/src/ui/modals/LoanEditModal.ts
+++ b/src/ui/modals/LoanEditModal.ts
@@ -15,6 +15,23 @@ import { Logger } from '../../utils/logger';
 
 type Mode = 'add' | 'edit';
 
+function escapeRegExp(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isoNextDay(iso: string): string {
+    const d = new Date(iso + 'T00:00:00Z');
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().slice(0, 10);
+}
+
+async function appendToFile(adapter: any, path: string, block: string): Promise<void> {
+    const exists = await adapter.exists(path);
+    const original = exists ? await adapter.read(path) : '';
+    const sep = !original ? '' : (original.endsWith('\n') ? '' : '\n');
+    await adapter.write(path, original + sep + block);
+}
+
 export class LoanEditModal extends Modal {
     plugin: BeancountPlugin;
     private component: any;
@@ -139,6 +156,13 @@ export class LoanEditModal extends Modal {
             }
             const next = applyLoanEdits(original, {}, [draft]);
             await adapter.write(path, next);
+            // Mirror the contractual principal as a real opening posting
+            // so the Balance Sheet (which reads sum(position)) lines up
+            // with the Liabilities & Receivables card (which falls back
+            // to the principal meta).
+            if (draft.principal !== null && draft.principal !== 0) {
+                await this.writeOpeningPostings(draft);
+            }
             return;
         }
 
@@ -147,6 +171,50 @@ export class LoanEditModal extends Modal {
         // since we key by `originalAccount`.
         const next = applyLoanEdits(original, { [originalAccount]: draft }, []);
         await adapter.write(path, next);
+    }
+
+    /**
+     * Append a `pad` + `balance` pair so a freshly-opened loan account
+     * starts with a real posting that matches its contractual principal.
+     * Idempotent: if the account already has a `pad` directive in
+     * pads.beancount we skip silently — the user's hand-written
+     * postings are the source of truth from then on.
+     *
+     * Sign convention:
+     *   - Liabilities  → balance is `-principal` (the user owes it)
+     *   - Receivables  → balance is `+principal` (the user is owed)
+     *
+     * Offsetting account: `Equity:OpeningBalances`. We don't try to
+     * create the offset account — we assume the structured-layout
+     * scaffolding already provided it (the plugin's onboarding does).
+     */
+    private async writeOpeningPostings(draft: LoanFormDraft): Promise<void> {
+        const folder = this.plugin.settings.structuredFolderName?.trim() || 'Finances';
+        const padsPath = `${folder}/pads.beancount`;
+        const balancesPath = `${folder}/balances.beancount`;
+        const adapter = this.plugin.app.vault.adapter;
+
+        // Skip if a pad for this account already exists (user-authored
+        // or earlier auto-write — either way, don't double up).
+        const padsContent = (await adapter.exists(padsPath)) ? await adapter.read(padsPath) : '';
+        const padPattern = new RegExp(`^\\d{4}-\\d{2}-\\d{2}\\s+pad\\s+${escapeRegExp(draft.account)}\\b`, 'm');
+        if (padPattern.test(padsContent)) {
+            Logger.log('[LoanEditModal] pad already exists for', draft.account, '— skipping auto-postings');
+            return;
+        }
+
+        const isReceivable = draft.account.startsWith('Assets:Receivables');
+        const sign = isReceivable ? '' : '-';
+        const padDate = draft.openDate;
+        const balDate = isoNextDay(padDate);
+        const principal = Math.abs(draft.principal!);
+        const offset = 'Equity:OpeningBalances';
+
+        const padBlock = `\n${padDate} pad ${draft.account}    ${offset}\n`;
+        const balBlock = `\n${balDate} balance ${draft.account}    ${sign}${principal} ${draft.currency}\n`;
+
+        await appendToFile(adapter, padsPath, padBlock);
+        await appendToFile(adapter, balancesPath, balBlock);
     }
 
     private async persistDelete(originalAccount: string): Promise<void> {

--- a/src/ui/modals/RecordPaymentModal.svelte
+++ b/src/ui/modals/RecordPaymentModal.svelte
@@ -66,7 +66,10 @@
 		<label class="field narrow">
 			<span>Date <em>*</em></span>
 			<input
-				type="date"
+				type="text"
+				inputmode="numeric"
+				placeholder="YYYY-MM-DD"
+				pattern="\d{4}-\d{2}-\d{2}"
 				bind:value={date}
 				class:error={errors.date}
 			/>

--- a/src/ui/modals/RecordPaymentModal.svelte
+++ b/src/ui/modals/RecordPaymentModal.svelte
@@ -1,0 +1,206 @@
+<!-- src/ui/modals/RecordPaymentModal.svelte -->
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import type { LoanRow } from '../../controllers/LiabilitiesController';
+	import { formatCurrencyAmount } from '../../utils/currency-precision';
+
+	export let loan: LoanRow;
+	export let accounts: string[] = [];
+	export let defaultFunding: string = '';
+
+	const dispatch = createEventDispatcher();
+
+	let date: string = new Date().toISOString().slice(0, 10);
+	let amount: number | null = loan.monthlyPayment ?? null;
+	let funding: string = ((loan.fundingAccount ?? defaultFunding) ?? '').trim();
+	let payee: string = loan.counterparty ?? '';
+	let narration: string = loan.role === 'receivable'
+		? `Repayment from ${loan.counterparty ?? loan.account}`
+		: `Payment to ${loan.counterparty ?? loan.account}`;
+
+	let errors: Record<string, string> = {};
+
+	$: assetAccounts = accounts.filter(a => a.startsWith('Assets'));
+	$: incomeAccounts = accounts.filter(a => a.startsWith('Income'));
+
+	function validate(): boolean {
+		errors = {};
+		if (!/^\d{4}-\d{2}-\d{2}$/.test(date.trim())) errors.date = 'Must be YYYY-MM-DD';
+		if (!amount || !isFinite(Number(amount)) || Number(amount) <= 0) errors.amount = 'Must be > 0';
+		if (!funding.trim()) errors.funding = 'Funding/destination account is required';
+		return Object.keys(errors).length === 0;
+	}
+
+	function handleSave() {
+		if (!validate()) return;
+		dispatch('save', {
+			date: date.trim(),
+			amount: Number(amount),
+			currency: loan.currency,
+			loanAccount: loan.account,
+			fundingAccount: funding.trim(),
+			payee: payee.trim() || null,
+			narration: narration.trim() || null,
+			role: loan.role,
+		});
+	}
+
+	function handleCancel() {
+		dispatch('cancel');
+	}
+</script>
+
+<div class="payment-modal">
+	<div class="loan-summary">
+		<div class="loan-name">{loan.account}</div>
+		<div class="loan-meta">
+			<span>Balance: <strong>{loan.currentBalanceDisplay}</strong></span>
+			{#if loan.monthlyPayment !== null}
+				<span class="sep">·</span>
+				<span>Monthly: <strong>{formatCurrencyAmount(loan.monthlyPayment, loan.currency)}</strong></span>
+			{/if}
+		</div>
+	</div>
+
+	<div class="row">
+		<label class="field narrow">
+			<span>Date <em>*</em></span>
+			<input
+				type="date"
+				bind:value={date}
+				class:error={errors.date}
+			/>
+			{#if errors.date}<span class="error-msg">{errors.date}</span>{/if}
+		</label>
+
+		<label class="field narrow">
+			<span>Amount <em>*</em> ({loan.currency})</span>
+			<input
+				type="number"
+				step="any"
+				bind:value={amount}
+				class:error={errors.amount}
+			/>
+			{#if errors.amount}<span class="error-msg">{errors.amount}</span>{/if}
+		</label>
+
+		<label class="field grow">
+			<span>{loan.role === 'receivable' ? 'Receiving account' : 'Funding account'} <em>*</em></span>
+			<input
+				type="text"
+				list="payment-funding-list"
+				placeholder={loan.role === 'receivable' ? 'Assets:Banking:…' : 'Assets:Banking:…'}
+				bind:value={funding}
+				class:error={errors.funding}
+			/>
+			<datalist id="payment-funding-list">
+				{#each [...assetAccounts, ...incomeAccounts] as a}
+					<option value={a} />
+				{/each}
+			</datalist>
+			{#if errors.funding}<span class="error-msg">{errors.funding}</span>{/if}
+		</label>
+	</div>
+
+	<div class="row">
+		<label class="field grow">
+			<span>Payee</span>
+			<input
+				type="text"
+				placeholder="e.g. {loan.counterparty ?? 'Banco Santander'}"
+				bind:value={payee}
+			/>
+		</label>
+		<label class="field grow">
+			<span>Narration</span>
+			<input
+				type="text"
+				bind:value={narration}
+			/>
+		</label>
+	</div>
+
+	<div class="footer">
+		<div class="footer-spacer"></div>
+		<button on:click={handleCancel}>Cancel</button>
+		<button class="cta" on:click={handleSave}>Record payment</button>
+	</div>
+</div>
+
+<style>
+	.payment-modal {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+	}
+	.loan-summary {
+		padding: var(--size-4-2) var(--size-4-3);
+		background: var(--background-secondary);
+		border-radius: var(--radius-s);
+	}
+	.loan-name {
+		font-weight: 600;
+		margin-bottom: 4px;
+	}
+	.loan-meta {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+	.loan-meta .sep {
+		margin: 0 6px;
+		color: var(--text-faint);
+	}
+	.row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-4-3);
+	}
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex: 1 1 160px;
+		min-width: 0;
+	}
+	.field.grow { flex: 1 1 240px; }
+	.field.narrow { flex: 0 0 130px; }
+	.field span {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+	}
+	.field em {
+		color: var(--color-red);
+		font-style: normal;
+	}
+	.field input {
+		width: 100%;
+		padding: 6px 8px;
+		border-radius: var(--radius-s);
+		border: 1px solid var(--background-modifier-border);
+		background: var(--background-primary);
+		color: var(--text-normal);
+	}
+	.field input.error { border-color: var(--color-red); }
+	.error-msg {
+		color: var(--color-red);
+		font-size: var(--font-ui-smaller);
+	}
+
+	.footer {
+		display: flex;
+		gap: 8px;
+		padding-top: var(--size-4-3);
+		border-top: 1px solid var(--background-modifier-border);
+	}
+	.footer-spacer { flex: 1; }
+	button {
+		padding: 6px 14px;
+		border-radius: var(--radius-s);
+		cursor: pointer;
+	}
+	.cta {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+		border: 1px solid var(--interactive-accent);
+	}
+</style>

--- a/src/ui/modals/RecordPaymentModal.ts
+++ b/src/ui/modals/RecordPaymentModal.ts
@@ -1,0 +1,137 @@
+// src/ui/modals/RecordPaymentModal.ts
+//
+// Lightweight modal that records a single payment against a loan-shaped
+// account. Builds a Beancount transaction and appends it to the user's
+// year-partitioned transactions file. No reliance on the heavier
+// UnifiedTransactionModal — this is a focused 4-field flow.
+
+import { App, Modal, Notice } from 'obsidian';
+import type BeancountPlugin from '../../main';
+import RecordPaymentModalComponent from './RecordPaymentModal.svelte';
+import type { LoanRow } from '../../controllers/LiabilitiesController';
+import { getOpenAccounts } from '../../utils/accounts';
+import { Logger } from '../../utils/logger';
+
+interface PaymentDetail {
+    date: string;
+    amount: number;
+    currency: string;
+    loanAccount: string;
+    fundingAccount: string;
+    payee: string | null;
+    narration: string | null;
+    role: 'liability' | 'receivable';
+}
+
+export class RecordPaymentModal extends Modal {
+    plugin: BeancountPlugin;
+    private component: any;
+    private loan: LoanRow;
+    private onSaved?: () => void;
+
+    constructor(
+        app: App,
+        plugin: BeancountPlugin,
+        opts: { loan: LoanRow; onSaved?: () => void },
+    ) {
+        super(app);
+        this.plugin = plugin;
+        this.loan = opts.loan;
+        this.onSaved = opts.onSaved;
+    }
+
+    private resolveTransactionsPath(year: number): string {
+        const folder = this.plugin.settings.structuredFolderName?.trim() || 'Finances';
+        return `${folder}/transactions/${year}.beancount`;
+    }
+
+    async onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.modalEl.style.maxWidth = '640px';
+        this.modalEl.style.width = '90vw';
+        this.setTitle('Record payment');
+
+        let accounts: string[] = [];
+        try {
+            accounts = (await getOpenAccounts(this.plugin)) ?? [];
+        } catch (e) {
+            Logger.log('[RecordPaymentModal] Could not prefetch accounts:', e);
+        }
+
+        const defaultFunding = this.loan.fundingAccount
+            || (this.loan.role === 'liability' ? 'Assets:Banking' : 'Income:Repayment');
+
+        this.component = new (RecordPaymentModalComponent as any)({
+            target: contentEl,
+            props: {
+                loan: this.loan,
+                accounts,
+                defaultFunding,
+            },
+        });
+
+        this.component.$on('save', async (e: any) => {
+            const detail = e.detail as PaymentDetail;
+            try {
+                await this.appendTransaction(detail);
+                new Notice('Payment recorded.');
+                this.close();
+                this.onSaved?.();
+            } catch (err) {
+                new Notice(`Failed to record: ${err instanceof Error ? err.message : String(err)}`);
+                Logger.error('[RecordPaymentModal] write error:', err);
+            }
+        });
+
+        this.component.$on('cancel', () => this.close());
+    }
+
+    /**
+     * Build a beancount transaction and append to transactions/<year>.beancount.
+     * For liabilities: loanAccount receives a positive posting (paying down debt),
+     * fundingAccount receives the matching negative (money out).
+     * For receivables: fundingAccount receives positive (money in), loanAccount
+     * receives negative (receivable shrinks).
+     */
+    private async appendTransaction(d: PaymentDetail): Promise<void> {
+        const adapter = this.plugin.app.vault.adapter;
+        const year = parseInt(d.date.slice(0, 4), 10);
+        const path = this.resolveTransactionsPath(year);
+
+        const exists = await adapter.exists(path);
+        const original = exists ? await adapter.read(path) : '';
+
+        const amountStr = String(d.amount);
+        const negStr = `-${amountStr}`;
+        const payeePart = d.payee ? `"${d.payee.replace(/"/g, '\\"')}"` : '""';
+        const narrPart = d.narration ? `"${d.narration.replace(/"/g, '\\"')}"` : '""';
+
+        const lines: string[] = [];
+        // Always lead with a blank line if the file already has content
+        // and isn't already trailing-blank.
+        if (original.length > 0 && !original.endsWith('\n\n')) {
+            if (!original.endsWith('\n')) lines.push('');
+            lines.push('');
+        }
+
+        lines.push(`${d.date} * ${payeePart} ${narrPart}`.replace(/\s+$/, ''));
+        if (d.role === 'liability') {
+            lines.push(`  ${d.loanAccount}  ${amountStr} ${d.currency}`);
+            lines.push(`  ${d.fundingAccount}  ${negStr} ${d.currency}`);
+        } else {
+            lines.push(`  ${d.fundingAccount}  ${amountStr} ${d.currency}`);
+            lines.push(`  ${d.loanAccount}  ${negStr} ${d.currency}`);
+        }
+
+        const next = original + lines.join('\n') + '\n';
+        await adapter.write(path, next);
+    }
+
+    onClose() {
+        if (this.component) {
+            this.component.$destroy();
+            this.component = null;
+        }
+    }
+}

--- a/src/ui/partials/dashboard/IncomeStatementTab.svelte
+++ b/src/ui/partials/dashboard/IncomeStatementTab.svelte
@@ -5,6 +5,7 @@
 	import { Logger } from '../../../utils/logger';
 	import SunburstChart from '../../common/SunburstChart.svelte';
 	import ChartComponent from '../../common/ChartComponent.svelte';
+	import { formatCurrencyAmount } from '../../../utils/currency-precision';
 
 	// Chart selector
 	let selectedChart: 'trend' | 'total' = 'trend';
@@ -323,7 +324,7 @@
 					</table>
 					<div class="section-total">
 						<span>Total Income</span>
-						<span class="total-amount">{state.totalIncome.toFixed(2)} {state.currency}</span>
+						<span class="total-amount">{formatCurrencyAmount(state.totalIncome, state.currency)}</span>
 					</div>
 				</div>
 
@@ -365,7 +366,7 @@
 					</table>
 					<div class="section-total">
 						<span>Total Expenses</span>
-						<span class="total-amount">{state.totalExpenses.toFixed(2)} {state.currency}</span>
+						<span class="total-amount">{formatCurrencyAmount(state.totalExpenses, state.currency)}</span>
 					</div>
 				</div>
 			</div>
@@ -374,7 +375,7 @@
 			<div class="net-profit-row">
 				<span class="net-profit-label">Net Profit</span>
 				<span class="net-profit-value {netProfitClass(state.netProfit)}">
-					{state.netProfit.toFixed(2)} {state.currency}
+					{formatCurrencyAmount(state.netProfit, state.currency)}
 				</span>
 			</div>
 		</div>

--- a/src/ui/partials/dashboard/LiabilitiesTab.svelte
+++ b/src/ui/partials/dashboard/LiabilitiesTab.svelte
@@ -1,0 +1,378 @@
+<!-- src/ui/partials/dashboard/LiabilitiesTab.svelte -->
+<script lang="ts">
+	import { writable, type Writable } from 'svelte/store';
+	import { MarkdownView } from 'obsidian';
+	import type { LiabilitiesController, LiabilitiesState, LoanRow } from '../../../controllers/LiabilitiesController';
+	import { nextDueDate, daysBetween, payoffFraction } from '../../../services/liabilities.service';
+
+	export let controller: LiabilitiesController;
+	export let plugin: any = null;
+
+	const placeholderState: Writable<LiabilitiesState> = writable({
+		isLoading: true, error: null, liabilities: [], receivables: [], sourcePath: '',
+		totalLiabilities: null, totalReceivables: null, currency: 'USD',
+	});
+
+	$: stateStore = controller ? controller.state : placeholderState;
+	$: state = $stateStore;
+
+	function formatNumber(n: number | null, opts: { signed?: boolean } = {}): string {
+		if (n === null) return '—';
+		const v = n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+		return opts.signed && n > 0 ? `+${v}` : v;
+	}
+
+	function formatPercent(n: number | null): string {
+		if (n === null) return '—';
+		return `${n.toFixed(2)}%`;
+	}
+
+	function todayIso(): string {
+		return new Date().toISOString().slice(0, 10);
+	}
+
+	function relativeDue(dueDay: number | null): string {
+		if (dueDay === null) return '';
+		const next = nextDueDate(dueDay, todayIso());
+		if (!next) return '';
+		const days = daysBetween(todayIso(), next);
+		if (days === 0) return 'today';
+		if (days === 1) return 'tomorrow';
+		if (days < 0) return `${Math.abs(days)}d ago`;
+		return `in ${days}d`;
+	}
+
+	function nextDueLabel(dueDay: number | null): string {
+		const next = nextDueDate(dueDay, todayIso());
+		return next ?? '—';
+	}
+
+	function payoffPct(row: LoanRow): number | null {
+		const f = payoffFraction(row.currentBalance, row.principal);
+		return f === null ? null : f * 100;
+	}
+
+	async function openSource(row: LoanRow) {
+		if (!plugin || !row.sourceLine) return;
+		try {
+			const file = plugin.app.vault.getAbstractFileByPath(state.sourcePath);
+			if (!file) return;
+			const leaf = plugin.app.workspace.getLeaf(true);
+			await leaf.openFile(file as any);
+			const view = leaf.view;
+			if (view instanceof MarkdownView && view.editor) {
+				const line = Math.max(0, (row.sourceLine ?? 1) - 1);
+				view.editor.setCursor({ line, ch: 0 });
+				view.editor.scrollIntoView({ from: { line, ch: 0 }, to: { line, ch: 0 } }, true);
+			}
+		} catch (_) {
+			/* defensive */
+		}
+	}
+
+	function handleRefresh() {
+		if (controller) controller.refresh();
+	}
+</script>
+
+<div class="liabilities-tab">
+	<div class="header">
+		<h3>Liabilities &amp; Receivables</h3>
+		<button class="refresh-button" on:click={handleRefresh} disabled={state.isLoading} title="Reload accounts file and balances">
+			{#if state.isLoading}
+				Refreshing…
+			{:else}
+				Refresh
+			{/if}
+		</button>
+	</div>
+
+	{#if state.error}
+		<p class="error-msg">Error: {state.error}</p>
+	{/if}
+
+	{#if state.isLoading && state.liabilities.length === 0 && state.receivables.length === 0}
+		<p class="muted">Loading…</p>
+	{:else}
+		<div class="kpis">
+			<div class="kpi-card">
+				<div class="kpi-label">Total liabilities</div>
+				<div class="kpi-value">{formatNumber(state.totalLiabilities)}</div>
+				<div class="kpi-foot">Sum of current balances</div>
+			</div>
+			<div class="kpi-card">
+				<div class="kpi-label">Total receivables</div>
+				<div class="kpi-value">{formatNumber(state.totalReceivables)}</div>
+				<div class="kpi-foot">Sum of current balances</div>
+			</div>
+		</div>
+
+		{#if state.liabilities.length === 0 && state.receivables.length === 0}
+			<div class="loan-empty-state">
+				<p>No loan-shaped accounts found.</p>
+				<p class="muted">
+					Add metadata to <code>open</code> directives in
+					<code>{state.sourcePath || 'accounts.beancount'}</code> like:
+				</p>
+				<pre><code>2026-01-01 open Liabilities:Credit:Visa  USD
+  loan-type: "credit-card"
+  principal: 50000
+  interest-rate: 29.5
+  monthly-payment: 5000
+  due-day: 10
+  counterparty: "Banco Santander"</code></pre>
+			</div>
+		{/if}
+
+		{#each [
+			{ title: 'Liabilities', rows: state.liabilities, accentClass: 'role-liability' },
+			{ title: 'Receivables', rows: state.receivables, accentClass: 'role-receivable' },
+		] as section}
+			{#if section.rows.length > 0}
+				<section class={section.accentClass}>
+					<h4>{section.title}</h4>
+					<div class="loan-grid">
+						{#each section.rows as row (row.account)}
+							{@const pct = payoffPct(row)}
+							<article class="loan-card">
+								<header class="loan-card-header">
+									<div class="account">
+										<span class="account-name">{row.account}</span>
+										{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
+									</div>
+									{#if plugin && row.sourceLine}
+										<button class="ghost" on:click={() => openSource(row)} title="Open accounts file at line {row.sourceLine}">↗</button>
+									{/if}
+								</header>
+
+								<div class="balance-block">
+									<span class="balance-label">Balance</span>
+									<span class="balance">{row.currentBalanceDisplay}</span>
+								</div>
+
+								<dl class="meta">
+									{#if row.counterparty}
+										<dt>Counterparty</dt><dd>{row.counterparty}</dd>
+									{/if}
+									{#if row.principal !== null}
+										<dt>Principal</dt><dd>{formatNumber(row.principal)} {row.currency}</dd>
+									{/if}
+									{#if row.interestRate !== null}
+										<dt>Interest</dt><dd>{formatPercent(row.interestRate)} APR</dd>
+									{/if}
+									{#if row.monthlyPayment !== null}
+										<dt>Monthly</dt><dd>{formatNumber(row.monthlyPayment)} {row.currency}</dd>
+									{/if}
+									{#if row.dueDay !== null}
+										<dt>Next due</dt>
+										<dd>
+											{nextDueLabel(row.dueDay)}
+											<span class="muted small">({relativeDue(row.dueDay)})</span>
+										</dd>
+									{/if}
+								</dl>
+
+								{#if pct !== null}
+									<div class="payoff" title="{pct.toFixed(1)}% paid off vs. principal">
+										<div class="payoff-bar"><div class="payoff-fill" style="width: {pct}%"></div></div>
+										<span class="payoff-label">{pct.toFixed(0)}% paid off</span>
+									</div>
+								{/if}
+							</article>
+						{/each}
+					</div>
+				</section>
+			{/if}
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.liabilities-tab {
+		padding: var(--size-4-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+	}
+
+	.header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding-bottom: var(--size-4-2);
+		border-bottom: 1px solid var(--background-modifier-border);
+	}
+
+	.refresh-button {
+		padding: 4px 10px;
+		border-radius: var(--radius-s);
+	}
+
+	.error-msg { color: var(--color-red); }
+	.muted { color: var(--text-muted); }
+	.small { font-size: var(--font-ui-smaller); }
+
+	.kpis {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: var(--size-4-3);
+	}
+	.kpi-card {
+		padding: var(--size-4-4);
+		background: var(--background-secondary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+	}
+	.kpi-label {
+		font-size: var(--font-ui-small);
+		color: var(--text-muted);
+		margin-bottom: var(--size-4-2);
+	}
+	.kpi-value {
+		font-size: 1.6em;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+	.kpi-foot {
+		margin-top: var(--size-4-1);
+		font-size: var(--font-ui-smaller);
+		color: var(--text-faint);
+	}
+
+	.loan-empty-state {
+		padding: var(--size-4-4);
+		border: 1px dashed var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		background: var(--background-secondary);
+	}
+	.loan-empty-state pre {
+		background: var(--background-primary);
+		padding: var(--size-4-3);
+		border-radius: var(--radius-s);
+		overflow-x: auto;
+	}
+
+	section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-2);
+	}
+
+	.loan-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: var(--size-4-3);
+	}
+
+	.loan-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-2);
+		padding: var(--size-4-3);
+		background: var(--background-primary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		border-top: 3px solid var(--background-modifier-border);
+	}
+	.role-liability .loan-card {
+		border-top-color: var(--color-red);
+	}
+	.role-receivable .loan-card {
+		border-top-color: var(--color-green);
+	}
+
+	.loan-card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 8px;
+	}
+	.account {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.account-name {
+		font-weight: 600;
+		font-size: var(--font-ui-small);
+		word-break: break-word;
+	}
+	.badge {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: 999px;
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		background: var(--background-modifier-hover);
+		color: var(--text-muted);
+		width: fit-content;
+	}
+
+	.balance-block {
+		display: flex;
+		flex-direction: column;
+	}
+	.balance-label {
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
+	}
+	.balance {
+		font-size: 1.4em;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+
+	dl.meta {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		column-gap: var(--size-4-3);
+		row-gap: 4px;
+		margin: 0;
+		font-size: var(--font-ui-small);
+	}
+	dl.meta dt {
+		color: var(--text-muted);
+	}
+	dl.meta dd {
+		margin: 0;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.payoff {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.payoff-bar {
+		flex: 1;
+		height: 6px;
+		background: var(--background-modifier-border);
+		border-radius: 999px;
+		overflow: hidden;
+	}
+	.payoff-fill {
+		height: 100%;
+		background: var(--interactive-accent);
+		transition: width 0.3s ease;
+	}
+	.payoff-label {
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ghost {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 4px 6px;
+		border-radius: var(--radius-s);
+	}
+	.ghost:hover {
+		color: var(--text-normal);
+		background: var(--background-modifier-hover);
+	}
+</style>

--- a/src/ui/partials/dashboard/LiabilitiesTab.svelte
+++ b/src/ui/partials/dashboard/LiabilitiesTab.svelte
@@ -3,8 +3,16 @@
 	import { writable, type Writable } from 'svelte/store';
 	import { MarkdownView } from 'obsidian';
 	import type { LiabilitiesController, LiabilitiesState, LoanRow } from '../../../controllers/LiabilitiesController';
-	import { nextDueDate, daysBetween, payoffFraction } from '../../../services/liabilities.service';
+	import {
+		nextDueDate,
+		daysBetween,
+		payoffFraction,
+		monthsRemaining,
+		type LoanFormDraft,
+	} from '../../../services/liabilities.service';
 	import { formatCurrency, formatCurrencyAmount } from '../../../utils/currency-precision';
+	import { LoanEditModal } from '../../modals/LoanEditModal';
+	import { RecordPaymentModal } from '../../modals/RecordPaymentModal';
 
 	export let controller: LiabilitiesController;
 	export let plugin: any = null;
@@ -18,6 +26,71 @@
 	$: state = $stateStore;
 
 	let searchTerm = '';
+
+	function rowToDraft(row: LoanRow): LoanFormDraft {
+		return {
+			account: row.account,
+			currency: row.currency,
+			openDate: row.openDate,
+			loanType: row.loanType,
+			counterparty: row.counterparty,
+			principal: row.principal,
+			interestRate: row.interestRate,
+			monthlyPayment: row.monthlyPayment,
+			dueDay: row.dueDay,
+			fundingAccount: row.fundingAccount,
+		};
+	}
+
+	function newDraftDefault(role: 'liability' | 'receivable' = 'liability'): LoanFormDraft {
+		const today = new Date().toISOString().slice(0, 10);
+		return {
+			account: role === 'liability' ? 'Liabilities:' : 'Assets:Receivables:',
+			currency: plugin?.settings?.operatingCurrency ?? 'USD',
+			openDate: today,
+			loanType: role === 'receivable' ? 'receivable' : 'credit-card',
+			counterparty: null,
+			principal: null,
+			interestRate: null,
+			monthlyPayment: null,
+			dueDay: null,
+			fundingAccount: null,
+		};
+	}
+
+	function openAddModal(role: 'liability' | 'receivable' = 'liability') {
+		if (!plugin) return;
+		new LoanEditModal(plugin.app, plugin, {
+			mode: 'add',
+			initial: newDraftDefault(role),
+			onSaved: () => controller?.refresh(),
+		}).open();
+	}
+
+	function openEditModal(row: LoanRow) {
+		if (!plugin) return;
+		new LoanEditModal(plugin.app, plugin, {
+			mode: 'edit',
+			initial: rowToDraft(row),
+			onSaved: () => controller?.refresh(),
+		}).open();
+	}
+
+	function openPaymentModal(row: LoanRow) {
+		if (!plugin) return;
+		new RecordPaymentModal(plugin.app, plugin, {
+			loan: row,
+			onSaved: () => controller?.refresh(),
+		}).open();
+	}
+
+	function formatMonths(n: number | null): string {
+		if (n === null) return '';
+		if (n < 1) return '< 1 mo';
+		if (n < 24) return `${Math.round(n)} mo`;
+		const years = n / 12;
+		return `${years.toFixed(years < 10 ? 1 : 0)} yr`;
+	}
 
 	function formatPercent(n: number | null): string {
 		if (n === null) return '—';
@@ -151,6 +224,9 @@
 <div class="liabilities-tab">
 	<div class="header">
 		<h3>Liabilities &amp; Receivables</h3>
+		<div class="header-actions">
+			<button class="add-button" on:click={() => openAddModal('liability')} disabled={!plugin} title="Add a new Liabilities:* account">+ Liability</button>
+			<button class="add-button" on:click={() => openAddModal('receivable')} disabled={!plugin} title="Add a new Assets:Receivables:* account">+ Receivable</button>
 		<button
 			class="refresh-button"
 			on:click={handleRefresh}
@@ -172,6 +248,7 @@
 				Refresh
 			{/if}
 		</button>
+		</div>
 	</div>
 
 	{#if state.error}
@@ -218,7 +295,7 @@
 			<div class="loan-empty-state">
 				<p class="empty-title">No loan-shaped accounts found.</p>
 				<p class="muted">
-					Add metadata to <code>open</code> directives in
+					Click <strong>+ Liability</strong> or <strong>+ Receivable</strong> above to create the first one — or add metadata directly to an <code>open</code> directive in
 					<code>{state.sourcePath || 'accounts.beancount'}</code> like:
 				</p>
 				<pre><code>2026-01-01 open Liabilities:Credit:Visa  USD
@@ -264,17 +341,22 @@
 								{@const pct = payoffPct(row)}
 								{@const above = isAboveBudget(row)}
 								{@const abovePct = aboveBudgetPct(row)}
+								{@const months = monthsRemaining(row.currentBalance, row.monthlyPayment)}
 								<article class="loan-card {urgencyClass(row.dueDay)}" class:above-principal={above}>
 									<header class="loan-card-header">
 										<div class="account">
-											<div class="account-name-row">
-												<span class="account-name" title={row.account}>{row.account}</span>
-												{#if plugin && row.sourceLine}
+											<span class="account-name" title={row.account}>{row.account}</span>
+											{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
+										</div>
+										{#if plugin}
+											<div class="card-actions">
+												<button class="ghost small-btn" on:click={() => openPaymentModal(row)} title="Record a payment to this account">$</button>
+												<button class="ghost small-btn" on:click={() => openEditModal(row)} title="Edit metadata in accounts.beancount">✎</button>
+												{#if row.sourceLine}
 													<button class="ghost small-btn" on:click={() => openSource(row)} title="Open accounts file at line {row.sourceLine}">↗</button>
 												{/if}
 											</div>
-											{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
-										</div>
+										{/if}
 									</header>
 
 									<div class="balance-block">
@@ -316,6 +398,12 @@
 											{/if}
 										</div>
 									{/if}
+
+									{#if months !== null}
+										<div class="projection muted small" title="Naive ETA: |balance| / |monthly|. Doesn't account for interest.">
+											{row.role === 'receivable' ? 'Recover in' : 'Payoff in'} ≈ {formatMonths(months)}
+										</div>
+									{/if}
 								</article>
 							{/each}
 						</div>
@@ -342,6 +430,25 @@
 		border-bottom: 1px solid var(--background-modifier-border);
 	}
 	.header h3 { margin: 0; font-size: var(--font-ui-larger); }
+
+	.header-actions {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+	.add-button {
+		padding: var(--size-4-1) var(--size-4-3);
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+		border: 1px solid var(--interactive-accent);
+		border-radius: var(--radius-s);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
+	}
+	.add-button:hover:not(:disabled) {
+		filter: brightness(1.05);
+	}
+	.add-button:disabled { opacity: 0.5; cursor: not-allowed; }
 
 	.refresh-button {
 		display: flex;
@@ -501,20 +608,19 @@
 		min-width: 0;
 		flex: 1;
 	}
-	.account-name-row {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-		min-width: 0;
-	}
 	.account-name {
 		font-weight: 600;
 		font-size: var(--font-ui-small);
-		flex: 1;
 		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		display: block;
+	}
+	.card-actions {
+		display: flex;
+		gap: 2px;
+		flex-shrink: 0;
 	}
 	.badge {
 		display: inline-block;
@@ -586,6 +692,11 @@
 		white-space: nowrap;
 	}
 	.payoff-label.warn { color: var(--color-red); font-weight: 600; }
+
+	.projection {
+		font-style: italic;
+		opacity: 0.85;
+	}
 
 	.ghost {
 		background: transparent;

--- a/src/ui/partials/dashboard/LiabilitiesTab.svelte
+++ b/src/ui/partials/dashboard/LiabilitiesTab.svelte
@@ -4,6 +4,7 @@
 	import { MarkdownView } from 'obsidian';
 	import type { LiabilitiesController, LiabilitiesState, LoanRow } from '../../../controllers/LiabilitiesController';
 	import { nextDueDate, daysBetween, payoffFraction } from '../../../services/liabilities.service';
+	import { formatCurrency, formatCurrencyAmount } from '../../../utils/currency-precision';
 
 	export let controller: LiabilitiesController;
 	export let plugin: any = null;
@@ -16,15 +17,14 @@
 	$: stateStore = controller ? controller.state : placeholderState;
 	$: state = $stateStore;
 
-	function formatNumber(n: number | null, opts: { signed?: boolean } = {}): string {
-		if (n === null) return '—';
-		const v = n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-		return opts.signed && n > 0 ? `+${v}` : v;
-	}
+	let searchTerm = '';
 
 	function formatPercent(n: number | null): string {
 		if (n === null) return '—';
-		return `${n.toFixed(2)}%`;
+		// Trim trailing zeros: 29.50 → "29.5%", 29.00 → "29%"
+		const fixed = n.toFixed(2);
+		const trimmed = fixed.replace(/\.?0+$/, '');
+		return `${trimmed}%`;
 	}
 
 	function todayIso(): string {
@@ -47,10 +47,83 @@
 		return next ?? '—';
 	}
 
+	function urgencyClass(dueDay: number | null): string {
+		if (dueDay === null) return '';
+		const next = nextDueDate(dueDay, todayIso());
+		if (!next) return '';
+		const days = daysBetween(todayIso(), next);
+		if (days < 0) return 'urgency-overdue';
+		if (days <= 7) return 'urgency-soon';
+		return '';
+	}
+
 	function payoffPct(row: LoanRow): number | null {
 		const f = payoffFraction(row.currentBalance, row.principal);
 		return f === null ? null : f * 100;
 	}
+
+	function isAboveBudget(row: LoanRow): boolean {
+		if (row.principal === null || row.currentBalance === null) return false;
+		return Math.abs(row.currentBalance) > Math.abs(row.principal);
+	}
+
+	function aboveBudgetPct(row: LoanRow): number | null {
+		if (!isAboveBudget(row) || row.principal === null) return null;
+		const ratio = Math.abs(row.currentBalance ?? 0) / Math.abs(row.principal);
+		return (ratio - 1) * 100;
+	}
+
+	// Sort key: next-due ascending (overdue first), accounts without
+	// dueDay sort to the end. Stable on account name.
+	function sortKey(row: LoanRow): number {
+		if (row.dueDay === null) return Number.POSITIVE_INFINITY;
+		const next = nextDueDate(row.dueDay, todayIso());
+		if (!next) return Number.POSITIVE_INFINITY;
+		return daysBetween(todayIso(), next);
+	}
+
+	function sortRows(rows: LoanRow[]): LoanRow[] {
+		return [...rows].sort((a, b) => {
+			const ka = sortKey(a), kb = sortKey(b);
+			if (ka !== kb) return ka - kb;
+			return a.account.localeCompare(b.account);
+		});
+	}
+
+	function rowMatches(row: LoanRow, term: string): boolean {
+		if (!term.trim()) return true;
+		const t = term.toLowerCase();
+		return (
+			row.account.toLowerCase().includes(t) ||
+			(row.loanType ?? '').toLowerCase().includes(t) ||
+			(row.counterparty ?? '').toLowerCase().includes(t)
+		);
+	}
+
+	// Currency-grouped totals (a single sum across mixed currencies is
+	// meaningless — show one tile per (role, currency) instead).
+	type CurrencyTotal = { currency: string; total: number; count: number };
+
+	function groupByCurrency(rows: LoanRow[]): CurrencyTotal[] {
+		const map = new Map<string, { total: number; count: number }>();
+		for (const r of rows) {
+			if (r.currentBalance === null) continue;
+			const ccy = r.currency || '—';
+			const entry = map.get(ccy) ?? { total: 0, count: 0 };
+			entry.total += r.currentBalance;
+			entry.count += 1;
+			map.set(ccy, entry);
+		}
+		return Array.from(map.entries())
+			.map(([currency, v]) => ({ currency, total: v.total, count: v.count }))
+			.sort((a, b) => a.currency.localeCompare(b.currency));
+	}
+
+	$: filteredLiabilities = sortRows((state.liabilities ?? []).filter(r => rowMatches(r, searchTerm)));
+	$: filteredReceivables = sortRows((state.receivables ?? []).filter(r => rowMatches(r, searchTerm)));
+	$: liabilityTotalsByCcy = groupByCurrency(state.liabilities ?? []);
+	$: receivableTotalsByCcy = groupByCurrency(state.receivables ?? []);
+	$: hasAnyAccount = (state.liabilities?.length ?? 0) + (state.receivables?.length ?? 0) > 0;
 
 	async function openSource(row: LoanRow) {
 		if (!plugin || !row.sourceLine) return;
@@ -78,10 +151,24 @@
 <div class="liabilities-tab">
 	<div class="header">
 		<h3>Liabilities &amp; Receivables</h3>
-		<button class="refresh-button" on:click={handleRefresh} disabled={state.isLoading} title="Reload accounts file and balances">
+		<button
+			class="refresh-button"
+			on:click={handleRefresh}
+			disabled={state.isLoading}
+			title="Reload accounts file and balances"
+		>
 			{#if state.isLoading}
+				<svg class="spinner" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M21 12a9 9 0 11-6.219-8.56"/>
+				</svg>
 				Refreshing…
 			{:else}
+				<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M3 12a9 9 0 013.5-7.1"/>
+					<path d="M20.5 5.5a9 9 0 01.5 6.5"/>
+					<path d="M3 12a9 9 0 016.5 8.1"/>
+					<path d="M20.5 18.5a9 9 0 01-6.5-5.5"/>
+				</svg>
 				Refresh
 			{/if}
 		</button>
@@ -91,25 +178,45 @@
 		<p class="error-msg">Error: {state.error}</p>
 	{/if}
 
-	{#if state.isLoading && state.liabilities.length === 0 && state.receivables.length === 0}
+	{#if state.isLoading && !hasAnyAccount}
 		<p class="muted">Loading…</p>
 	{:else}
-		<div class="kpis">
-			<div class="kpi-card">
-				<div class="kpi-label">Total liabilities</div>
-				<div class="kpi-value">{formatNumber(state.totalLiabilities)}</div>
-				<div class="kpi-foot">Sum of current balances</div>
+		<!-- Currency-grouped totals: one tile per (role, currency) pair,
+		     since summing across currencies would produce a meaningless number. -->
+		{#if hasAnyAccount}
+			<div class="totals-row">
+				{#each liabilityTotalsByCcy as t (t.currency)}
+					<div class="total-tile total-liability">
+						<div class="total-label">Liabilities ({t.currency})</div>
+						<div class="total-value">{formatCurrency(t.total, t.currency)} <span class="ccy">{t.currency}</span></div>
+						<div class="total-meta">{t.count} {t.count === 1 ? 'account' : 'accounts'}</div>
+					</div>
+				{/each}
+				{#each receivableTotalsByCcy as t (t.currency)}
+					<div class="total-tile total-receivable">
+						<div class="total-label">Receivables ({t.currency})</div>
+						<div class="total-value">{formatCurrency(t.total, t.currency)} <span class="ccy">{t.currency}</span></div>
+						<div class="total-meta">{t.count} {t.count === 1 ? 'account' : 'accounts'}</div>
+					</div>
+				{/each}
 			</div>
-			<div class="kpi-card">
-				<div class="kpi-label">Total receivables</div>
-				<div class="kpi-value">{formatNumber(state.totalReceivables)}</div>
-				<div class="kpi-foot">Sum of current balances</div>
-			</div>
-		</div>
 
-		{#if state.liabilities.length === 0 && state.receivables.length === 0}
+			<div class="filter-row">
+				<input
+					type="search"
+					class="search"
+					placeholder="Filter by account, loan type, or counterparty…"
+					bind:value={searchTerm}
+				/>
+				{#if searchTerm}
+					<button class="ghost reset" on:click={() => (searchTerm = '')} title="Clear filter">✕</button>
+				{/if}
+			</div>
+		{/if}
+
+		{#if !hasAnyAccount}
 			<div class="loan-empty-state">
-				<p>No loan-shaped accounts found.</p>
+				<p class="empty-title">No loan-shaped accounts found.</p>
 				<p class="muted">
 					Add metadata to <code>open</code> directives in
 					<code>{state.sourcePath || 'accounts.beancount'}</code> like:
@@ -121,66 +228,98 @@
   monthly-payment: 5000
   due-day: 10
   counterparty: "Banco Santander"</code></pre>
+				<p class="muted small">
+					Recognised keys: <code>loan-type</code>, <code>principal</code>,
+					<code>interest-rate</code>, <code>monthly-payment</code>,
+					<code>due-day</code>, <code>counterparty</code>,
+					<code>funding-account</code>. All are optional; an account is
+					also picked up automatically if its name starts with
+					<code>Liabilities:</code> or <code>Assets:Receivables</code>.
+				</p>
 			</div>
 		{/if}
 
 		{#each [
-			{ title: 'Liabilities', rows: state.liabilities, accentClass: 'role-liability' },
-			{ title: 'Receivables', rows: state.receivables, accentClass: 'role-receivable' },
+			{ title: 'Liabilities', rows: filteredLiabilities, accentClass: 'role-liability', total: state.liabilities.length },
+			{ title: 'Receivables', rows: filteredReceivables, accentClass: 'role-receivable', total: state.receivables.length },
 		] as section}
-			{#if section.rows.length > 0}
+			{#if section.total > 0}
 				<section class={section.accentClass}>
-					<h4>{section.title}</h4>
-					<div class="loan-grid">
-						{#each section.rows as row (row.account)}
-							{@const pct = payoffPct(row)}
-							<article class="loan-card">
-								<header class="loan-card-header">
-									<div class="account">
-										<span class="account-name">{row.account}</span>
-										{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
-									</div>
-									{#if plugin && row.sourceLine}
-										<button class="ghost" on:click={() => openSource(row)} title="Open accounts file at line {row.sourceLine}">↗</button>
-									{/if}
-								</header>
-
-								<div class="balance-block">
-									<span class="balance-label">Balance</span>
-									<span class="balance">{row.currentBalanceDisplay}</span>
-								</div>
-
-								<dl class="meta">
-									{#if row.counterparty}
-										<dt>Counterparty</dt><dd>{row.counterparty}</dd>
-									{/if}
-									{#if row.principal !== null}
-										<dt>Principal</dt><dd>{formatNumber(row.principal)} {row.currency}</dd>
-									{/if}
-									{#if row.interestRate !== null}
-										<dt>Interest</dt><dd>{formatPercent(row.interestRate)} APR</dd>
-									{/if}
-									{#if row.monthlyPayment !== null}
-										<dt>Monthly</dt><dd>{formatNumber(row.monthlyPayment)} {row.currency}</dd>
-									{/if}
-									{#if row.dueDay !== null}
-										<dt>Next due</dt>
-										<dd>
-											{nextDueLabel(row.dueDay)}
-											<span class="muted small">({relativeDue(row.dueDay)})</span>
-										</dd>
-									{/if}
-								</dl>
-
-								{#if pct !== null}
-									<div class="payoff" title="{pct.toFixed(1)}% paid off vs. principal">
-										<div class="payoff-bar"><div class="payoff-fill" style="width: {pct}%"></div></div>
-										<span class="payoff-label">{pct.toFixed(0)}% paid off</span>
-									</div>
-								{/if}
-							</article>
-						{/each}
+					<div class="section-header">
+						<h4>{section.title}</h4>
+						<span class="muted small">
+							{#if searchTerm && section.rows.length !== section.total}
+								{section.rows.length} of {section.total}
+							{:else}
+								{section.total} {section.total === 1 ? 'account' : 'accounts'}
+							{/if}
+						</span>
 					</div>
+
+					{#if section.rows.length === 0}
+						<p class="muted small">No matches.</p>
+					{:else}
+						<div class="loan-grid">
+							{#each section.rows as row (row.account)}
+								{@const pct = payoffPct(row)}
+								{@const above = isAboveBudget(row)}
+								{@const abovePct = aboveBudgetPct(row)}
+								<article class="loan-card {urgencyClass(row.dueDay)}" class:above-principal={above}>
+									<header class="loan-card-header">
+										<div class="account">
+											<div class="account-name-row">
+												<span class="account-name" title={row.account}>{row.account}</span>
+												{#if plugin && row.sourceLine}
+													<button class="ghost small-btn" on:click={() => openSource(row)} title="Open accounts file at line {row.sourceLine}">↗</button>
+												{/if}
+											</div>
+											{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
+										</div>
+									</header>
+
+									<div class="balance-block">
+										<span class="balance-label">Balance</span>
+										<span class="balance">{row.currentBalanceDisplay}</span>
+									</div>
+
+									<dl class="meta">
+										{#if row.counterparty}
+											<dt>Counterparty</dt><dd>{row.counterparty}</dd>
+										{/if}
+										{#if row.principal !== null}
+											<dt>Principal</dt><dd>{formatCurrencyAmount(row.principal, row.currency)}</dd>
+										{/if}
+										{#if row.interestRate !== null}
+											<dt>Interest</dt><dd>{formatPercent(row.interestRate)} APR</dd>
+										{/if}
+										{#if row.monthlyPayment !== null}
+											<dt>Monthly</dt><dd>{formatCurrencyAmount(row.monthlyPayment, row.currency)}</dd>
+										{/if}
+										{#if row.dueDay !== null}
+											<dt>Next due</dt>
+											<dd>
+												{nextDueLabel(row.dueDay)}
+												<span class="due-rel">({relativeDue(row.dueDay)})</span>
+											</dd>
+										{/if}
+									</dl>
+
+									{#if pct !== null}
+										<div class="payoff" title={above ? `${abovePct?.toFixed(1)}% above principal` : `${pct.toFixed(1)}% paid off vs. principal`}>
+											<div class="payoff-bar">
+												<div class="payoff-fill" style="width: {pct}%"></div>
+											</div>
+											{#if above}
+												<span class="payoff-label warn">+{abovePct?.toFixed(0)}% above principal</span>
+											{:else}
+												<span class="payoff-label">{pct.toFixed(0)}% paid off</span>
+											{/if}
+										</div>
+									{/if}
+								</article>
+							{/each}
+						</div>
+					{/if}
 				</section>
 			{/if}
 		{/each}
@@ -202,48 +341,99 @@
 		padding-bottom: var(--size-4-2);
 		border-bottom: 1px solid var(--background-modifier-border);
 	}
+	.header h3 { margin: 0; font-size: var(--font-ui-larger); }
 
 	.refresh-button {
-		padding: 4px 10px;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: var(--size-4-1) var(--size-4-3);
+		background: var(--interactive-normal);
+		border: 1px solid var(--background-modifier-border);
 		border-radius: var(--radius-s);
+		color: var(--text-normal);
+		cursor: pointer;
+		font-size: var(--font-ui-small);
 	}
+	.refresh-button:hover:not(:disabled) { background: var(--interactive-hover); }
+	.refresh-button:disabled { opacity: 0.6; cursor: not-allowed; }
+	.spinner { animation: spin 1s linear infinite; }
+	@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 
 	.error-msg { color: var(--color-red); }
 	.muted { color: var(--text-muted); }
 	.small { font-size: var(--font-ui-smaller); }
 
-	.kpis {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	/* Currency-grouped totals row — variable number of tiles, wraps. */
+	.totals-row {
+		display: flex;
+		flex-wrap: wrap;
 		gap: var(--size-4-3);
 	}
-	.kpi-card {
-		padding: var(--size-4-4);
+	.total-tile {
+		flex: 1 1 200px;
+		min-width: 200px;
+		padding: var(--size-4-3) var(--size-4-4);
 		background: var(--background-secondary);
 		border: 1px solid var(--background-modifier-border);
 		border-radius: var(--radius-m);
+		border-left: 3px solid var(--background-modifier-border);
 	}
-	.kpi-label {
+	.total-tile.total-liability { border-left-color: var(--color-red); }
+	.total-tile.total-receivable { border-left-color: var(--color-green); }
+	.total-label {
 		font-size: var(--font-ui-small);
 		color: var(--text-muted);
-		margin-bottom: var(--size-4-2);
+		margin-bottom: 2px;
 	}
-	.kpi-value {
-		font-size: 1.6em;
+	.total-value {
+		font-size: 1.4em;
 		font-weight: 700;
 		font-variant-numeric: tabular-nums;
 	}
-	.kpi-foot {
+	.total-value .ccy {
+		font-size: 0.6em;
+		font-weight: 600;
+		color: var(--text-muted);
+		margin-left: 4px;
+	}
+	.total-meta {
 		margin-top: var(--size-4-1);
 		font-size: var(--font-ui-smaller);
 		color: var(--text-faint);
 	}
 
+	/* Filter row */
+	.filter-row {
+		display: flex;
+		gap: 6px;
+		align-items: center;
+	}
+	.search {
+		flex: 1;
+		padding: 6px 10px;
+		border-radius: var(--radius-s);
+		border: 1px solid var(--background-modifier-border);
+		background: var(--background-primary);
+		color: var(--text-normal);
+		font-size: var(--font-ui-small);
+	}
+	.reset {
+		padding: 4px 10px;
+		border-radius: var(--radius-s);
+	}
+
+	/* Empty state — scoped class to avoid colliding with Obsidian's
+	   global .empty-state rule. */
 	.loan-empty-state {
 		padding: var(--size-4-4);
 		border: 1px dashed var(--background-modifier-border);
 		border-radius: var(--radius-m);
 		background: var(--background-secondary);
+	}
+	.loan-empty-state .empty-title {
+		margin-top: 0;
+		font-weight: 600;
 	}
 	.loan-empty-state pre {
 		background: var(--background-primary);
@@ -252,12 +442,21 @@
 		overflow-x: auto;
 	}
 
+	/* Section blocks */
 	section {
 		display: flex;
 		flex-direction: column;
 		gap: var(--size-4-2);
 	}
+	.section-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+	}
+	.section-header h4 { margin: 0; }
 
+	/* Card grid */
 	.loan-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -272,14 +471,22 @@
 		background: var(--background-primary);
 		border: 1px solid var(--background-modifier-border);
 		border-radius: var(--radius-m);
-		border-top: 3px solid var(--background-modifier-border);
+		border-left: 3px solid var(--background-modifier-border);
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
 	}
-	.role-liability .loan-card {
-		border-top-color: var(--color-red);
+	.role-liability .loan-card { border-left-color: var(--color-red); }
+	.role-receivable .loan-card { border-left-color: var(--color-green); }
+
+	/* Urgency overrides — overdue is the strongest cue, then due-soon. */
+	.loan-card.urgency-overdue {
+		border-left-color: var(--color-red);
+		box-shadow: inset 4px 0 0 var(--color-red), 0 0 0 1px var(--color-red);
 	}
-	.role-receivable .loan-card {
-		border-top-color: var(--color-green);
+	.loan-card.urgency-soon {
+		border-left-color: var(--color-orange, var(--text-warning));
+		box-shadow: inset 4px 0 0 var(--color-orange, var(--text-warning));
 	}
+	.loan-card.above-principal { background: color-mix(in srgb, var(--color-red), transparent 95%); }
 
 	.loan-card-header {
 		display: flex;
@@ -291,11 +498,23 @@
 		display: flex;
 		flex-direction: column;
 		gap: 4px;
+		min-width: 0;
+		flex: 1;
+	}
+	.account-name-row {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		min-width: 0;
 	}
 	.account-name {
 		font-weight: 600;
 		font-size: var(--font-ui-small);
-		word-break: break-word;
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 	.badge {
 		display: inline-block;
@@ -332,12 +551,15 @@
 		margin: 0;
 		font-size: var(--font-ui-small);
 	}
-	dl.meta dt {
-		color: var(--text-muted);
-	}
+	dl.meta dt { color: var(--text-muted); }
 	dl.meta dd {
 		margin: 0;
 		font-variant-numeric: tabular-nums;
+	}
+	.due-rel {
+		font-size: var(--font-ui-smaller);
+		color: var(--text-muted);
+		margin-left: 4px;
 	}
 
 	.payoff {
@@ -361,7 +583,9 @@
 		font-size: var(--font-ui-smaller);
 		color: var(--text-muted);
 		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
 	}
+	.payoff-label.warn { color: var(--color-red); font-weight: 600; }
 
 	.ghost {
 		background: transparent;
@@ -375,4 +599,5 @@
 		color: var(--text-normal);
 		background: var(--background-modifier-hover);
 	}
+	.small-btn { padding: 0 6px; font-size: var(--font-ui-small); }
 </style>

--- a/src/ui/partials/dashboard/LiabilitiesTab.svelte
+++ b/src/ui/partials/dashboard/LiabilitiesTab.svelte
@@ -373,8 +373,15 @@
 									</header>
 
 									<div class="balance-block">
-										<span class="balance-label">Balance</span>
-										<span class="balance">{row.currentBalanceDisplay}</span>
+										<span class="balance-label">
+											Balance
+											{#if row.balanceSource === 'principal'}
+												<span class="balance-source" title="No postings yet — showing the principal from the open-directive metadata">expected, from principal</span>
+											{:else if row.balanceSource === 'unknown'}
+												<span class="balance-source warn" title="Balance query failed — could not read postings">balance unavailable</span>
+											{/if}
+										</span>
+										<span class="balance" class:expected={row.balanceSource === 'principal'}>{row.currentBalanceDisplay}</span>
 									</div>
 
 									<dl class="meta">
@@ -680,6 +687,28 @@
 	.balance-label {
 		font-size: var(--font-ui-smaller);
 		color: var(--text-muted);
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 6px;
+	}
+	.balance-source {
+		font-style: italic;
+		font-size: 10px;
+		padding: 1px 8px;
+		border-radius: 999px;
+		background: var(--background-modifier-hover);
+		color: var(--text-muted);
+		text-transform: lowercase;
+		letter-spacing: 0.02em;
+	}
+	.balance-source.warn {
+		color: var(--color-orange, var(--text-warning));
+		background: color-mix(in srgb, var(--color-orange, var(--text-warning)), transparent 88%);
+	}
+	.balance.expected {
+		font-style: italic;
+		opacity: 0.92;
 	}
 	.balance {
 		font-size: 1.4em;

--- a/src/ui/partials/dashboard/LiabilitiesTab.svelte
+++ b/src/ui/partials/dashboard/LiabilitiesTab.svelte
@@ -39,6 +39,9 @@
 			monthlyPayment: row.monthlyPayment,
 			dueDay: row.dueDay,
 			fundingAccount: row.fundingAccount,
+			paymentMode: row.paymentMode,
+			payoffDate: row.payoffDate,
+			payoffAmount: row.payoffAmount,
 		};
 	}
 
@@ -55,6 +58,9 @@
 			monthlyPayment: null,
 			dueDay: null,
 			fundingAccount: null,
+			paymentMode: 'recurring',
+			payoffDate: null,
+			payoffAmount: null,
 		};
 	}
 
@@ -104,25 +110,28 @@
 		return new Date().toISOString().slice(0, 10);
 	}
 
-	function relativeDue(dueDay: number | null): string {
-		if (dueDay === null) return '';
-		const next = nextDueDate(dueDay, todayIso());
-		if (!next) return '';
-		const days = daysBetween(todayIso(), next);
+	/**
+	 * The "next event" for a loan card depends on its payment mode:
+	 *   - recurring → the next monthly due-day occurrence.
+	 *   - one-time → the configured payoff date.
+	 * Returns ISO YYYY-MM-DD or null when the loan has no schedule.
+	 */
+	function nextEventDate(row: LoanRow): string | null {
+		if (row.paymentMode === 'one-time') return row.payoffDate;
+		return nextDueDate(row.dueDay, todayIso());
+	}
+
+	function relativeDate(iso: string | null): string {
+		if (!iso) return '';
+		const days = daysBetween(todayIso(), iso);
 		if (days === 0) return 'today';
 		if (days === 1) return 'tomorrow';
 		if (days < 0) return `${Math.abs(days)}d ago`;
 		return `in ${days}d`;
 	}
 
-	function nextDueLabel(dueDay: number | null): string {
-		const next = nextDueDate(dueDay, todayIso());
-		return next ?? '—';
-	}
-
-	function urgencyClass(dueDay: number | null): string {
-		if (dueDay === null) return '';
-		const next = nextDueDate(dueDay, todayIso());
+	function urgencyClassForRow(row: LoanRow): string {
+		const next = nextEventDate(row);
 		if (!next) return '';
 		const days = daysBetween(todayIso(), next);
 		if (days < 0) return 'urgency-overdue';
@@ -146,11 +155,10 @@
 		return (ratio - 1) * 100;
 	}
 
-	// Sort key: next-due ascending (overdue first), accounts without
-	// dueDay sort to the end. Stable on account name.
+	// Sort key: next-event ascending (overdue first), accounts without
+	// any schedule sort to the end. Stable on account name.
 	function sortKey(row: LoanRow): number {
-		if (row.dueDay === null) return Number.POSITIVE_INFINITY;
-		const next = nextDueDate(row.dueDay, todayIso());
+		const next = nextEventDate(row);
 		if (!next) return Number.POSITIVE_INFINITY;
 		return daysBetween(todayIso(), next);
 	}
@@ -342,11 +350,16 @@
 								{@const above = isAboveBudget(row)}
 								{@const abovePct = aboveBudgetPct(row)}
 								{@const months = monthsRemaining(row.currentBalance, row.monthlyPayment)}
-								<article class="loan-card {urgencyClass(row.dueDay)}" class:above-principal={above}>
+								{@const isOneTime = row.paymentMode === 'one-time'}
+								{@const eventDate = nextEventDate(row)}
+								<article class="loan-card {urgencyClassForRow(row)}" class:above-principal={above} class:one-time={isOneTime}>
 									<header class="loan-card-header">
 										<div class="account">
 											<span class="account-name" title={row.account}>{row.account}</span>
-											{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
+											<div class="badges">
+												{#if row.loanType}<span class="badge">{row.loanType}</span>{/if}
+												{#if isOneTime}<span class="badge schedule-badge">one-time</span>{/if}
+											</div>
 										</div>
 										{#if plugin}
 											<div class="card-actions">
@@ -374,15 +387,28 @@
 										{#if row.interestRate !== null}
 											<dt>Interest</dt><dd>{formatPercent(row.interestRate)} APR</dd>
 										{/if}
-										{#if row.monthlyPayment !== null}
-											<dt>Monthly</dt><dd>{formatCurrencyAmount(row.monthlyPayment, row.currency)}</dd>
-										{/if}
-										{#if row.dueDay !== null}
-											<dt>Next due</dt>
-											<dd>
-												{nextDueLabel(row.dueDay)}
-												<span class="due-rel">({relativeDue(row.dueDay)})</span>
-											</dd>
+										{#if isOneTime}
+											{#if row.payoffAmount !== null}
+												<dt>Payoff total</dt><dd>{formatCurrencyAmount(row.payoffAmount, row.currency)}</dd>
+											{/if}
+											{#if row.payoffDate}
+												<dt>Pay off by</dt>
+												<dd>
+													{row.payoffDate}
+													<span class="due-rel">({relativeDate(row.payoffDate)})</span>
+												</dd>
+											{/if}
+										{:else}
+											{#if row.monthlyPayment !== null}
+												<dt>Monthly</dt><dd>{formatCurrencyAmount(row.monthlyPayment, row.currency)}</dd>
+											{/if}
+											{#if eventDate}
+												<dt>Next due</dt>
+												<dd>
+													{eventDate}
+													<span class="due-rel">({relativeDate(eventDate)})</span>
+												</dd>
+											{/if}
 										{/if}
 									</dl>
 
@@ -399,7 +425,7 @@
 										</div>
 									{/if}
 
-									{#if months !== null}
+									{#if !isOneTime && months !== null}
 										<div class="projection muted small" title="Naive ETA: |balance| / |monthly|. Doesn't account for interest.">
 											{row.role === 'receivable' ? 'Recover in' : 'Payoff in'} ≈ {formatMonths(months)}
 										</div>
@@ -622,6 +648,11 @@
 		gap: 2px;
 		flex-shrink: 0;
 	}
+	.badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
 	.badge {
 		display: inline-block;
 		padding: 2px 8px;
@@ -633,6 +664,13 @@
 		background: var(--background-modifier-hover);
 		color: var(--text-muted);
 		width: fit-content;
+	}
+	.schedule-badge {
+		background: color-mix(in srgb, var(--interactive-accent), transparent 80%);
+		color: var(--interactive-accent);
+	}
+	.loan-card.one-time .balance {
+		font-style: italic;
 	}
 
 	.balance-block {

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import type { CommodityInfo } from "../../../../controllers/CommoditiesController";
+	import { formatCurrencyAmount } from "../../../../utils/currency-precision";
 
 	export let commodity: CommodityInfo;
 	export let index: number = 0;
@@ -11,19 +12,15 @@
 
 	const dispatch = createEventDispatcher();
 
-	// Format the operating-currency equivalent (e.g. "≈ 471 UYU"). Uses the
-	// user's locale so thousands/decimals match other dashboard widgets.
+	// Format the operating-currency equivalent (e.g. "≈ 471 UYU"). Precision
+	// matches the operating currency's natural decimal places.
 	$: equivalentLabel = (() => {
 		if (!showHoldings || !showHoldingsValue) return "";
 		if (commodity?.isOperatingCurrency) return "";
 		if (!operatingCurrency) return "";
 		const value = commodity?.valueInOperatingCurrency;
 		if (typeof value !== "number" || !isFinite(value) || value <= 0) return "";
-		const formatted = value.toLocaleString(undefined, {
-			minimumFractionDigits: 0,
-			maximumFractionDigits: 2,
-		});
-		return `≈ ${formatted} ${operatingCurrency}`;
+		return `≈ ${formatCurrencyAmount(value, operatingCurrency)}`;
 	})();
 
 	function handleClick() {

--- a/src/ui/views/dashboard/UnifiedDashboardView.svelte
+++ b/src/ui/views/dashboard/UnifiedDashboardView.svelte
@@ -8,6 +8,7 @@
     import CommoditiesTab from '../../partials/dashboard/CommoditiesTab.svelte';
     import JournalTab from '../../partials/dashboard/JournalTab.svelte';
     import IncomeStatementTab from '../../partials/dashboard/IncomeStatementTab.svelte';
+    import LiabilitiesTab from '../../partials/dashboard/LiabilitiesTab.svelte';
 
     // Types
     import type { OverviewController } from '../../../controllers/OverviewController';
@@ -16,6 +17,7 @@
     import type { CommoditiesController } from '../../../controllers/CommoditiesController';
     import type { IncomeStatementController } from '../../../controllers/IncomeStatementController';
     import type { RecurringController } from '../../../controllers/RecurringController';
+    import type { LiabilitiesController } from '../../../controllers/LiabilitiesController';
 
     // Props
     export let overviewController: OverviewController;
@@ -24,6 +26,7 @@
     export let commoditiesController: CommoditiesController;
     export let incomeStatementController: IncomeStatementController;
     export let recurringController: RecurringController | null = null;
+    export let liabilitiesController: LiabilitiesController | null = null;
     export let journalStore: any;
     export let plugin: any = null; // Add plugin prop
 
@@ -35,6 +38,7 @@
         { id: 'journal', label: 'Journal' },
         { id: 'balancesheet', label: 'Accounts & Balances' },
         { id: 'incomestatement', label: 'Income Statement' },
+        { id: 'liabilities', label: 'Liabilities & Receivables' },
         { id: 'commodities', label: 'Commodities' }
     ];
 </script>
@@ -69,6 +73,10 @@
             <BalanceSheetTab controller={balanceSheetController} />
         {:else if activeTab === 'incomestatement'}
             <IncomeStatementTab controller={incomeStatementController} />
+        {:else if activeTab === 'liabilities'}
+            {#if liabilitiesController}
+                <LiabilitiesTab controller={liabilitiesController} {plugin} />
+            {/if}
         {:else if activeTab === 'commodities'}
             <CommoditiesTab controller={commoditiesController} {plugin} on:openCommodity on:addCommodity />
         {/if}

--- a/src/ui/views/dashboard/unified-dashboard-view.ts
+++ b/src/ui/views/dashboard/unified-dashboard-view.ts
@@ -13,6 +13,7 @@ import { BalanceSheetController } from '../../../controllers/BalanceSheetControl
 import { CommoditiesController } from '../../../controllers/CommoditiesController';
 import { IncomeStatementController } from '../../../controllers/IncomeStatementController';
 import { RecurringController } from '../../../controllers/RecurringController';
+import { LiabilitiesController } from '../../../controllers/LiabilitiesController';
 // JournalController is replaced by plugin.journalStore
 // -----------------------------
 
@@ -29,6 +30,7 @@ export class UnifiedDashboardView extends ItemView {
 	commoditiesController: CommoditiesController;
 	incomeStatementController: IncomeStatementController;
 	recurringController: RecurringController;
+	liabilitiesController: LiabilitiesController;
 
 	constructor(leaf: WorkspaceLeaf, plugin: BeancountPlugin) {
 		super(leaf);
@@ -40,6 +42,7 @@ export class UnifiedDashboardView extends ItemView {
 		this.commoditiesController = new CommoditiesController(this.plugin);
 		this.incomeStatementController = new IncomeStatementController(this.plugin);
 		this.recurringController = new RecurringController(this.plugin);
+		this.liabilitiesController = new LiabilitiesController(this.plugin);
 	}
 
 	getViewType(): string { return UNIFIED_DASHBOARD_VIEW_TYPE; }
@@ -56,6 +59,7 @@ export class UnifiedDashboardView extends ItemView {
 				this.incomeStatementController.loadData(),
 				this.commoditiesController.loadData(),
 				this.recurringController.loadData(),
+				this.liabilitiesController.loadData(),
 				this.plugin.journalStore.refresh() // Use new store
 			]);
 		} catch (error) {
@@ -77,6 +81,7 @@ export class UnifiedDashboardView extends ItemView {
 				incomeStatementController: this.incomeStatementController,
 				commoditiesController: this.commoditiesController,
 				recurringController: this.recurringController,
+				liabilitiesController: this.liabilitiesController,
 				journalStore: this.plugin.journalStore, // Pass store instead of controller
 				plugin: this.plugin // Pass plugin instance
 			}
@@ -105,6 +110,7 @@ export class UnifiedDashboardView extends ItemView {
 		this.transactionController.handleFilterChange({}); // Load initial transactions
 		this.balanceSheetController.loadData();
 		this.incomeStatementController.loadData();
+		this.liabilitiesController.loadData();
 	}
 
 	async onClose() {

--- a/src/utils/currency-precision.ts
+++ b/src/utils/currency-precision.ts
@@ -1,145 +1,77 @@
 // src/utils/currency-precision.ts
 //
-// Currency-aware number formatting. The dashboard previously rendered
-// every monetary value with a hard-coded 2-decimal toFixed/toLocaleString,
-// which over-rounded crypto (0.012 BTC → "0.01") and added meaningless
-// trailing zeros to currencies that have no fractional unit in real
-// circulation (UYU, JPY).
+// Currency-aware number handling. Two responsibilities:
 //
-// `getCurrencyPrecision` returns the natural decimal places for each
-// currency code. `formatCurrency` formats a number with that precision
-// and an adaptive override for tiny magnitudes so a sub-cent value
-// doesn't collapse to zero on the screen.
+//   1. Choose the BQL `round(N, k)` precision per currency so values
+//      survive the server-side roundtrip without losing real digits.
+//      (Beancount conversions can produce many decimals; we keep
+//      enough to faithfully represent every real currency.)
+//
+//   2. Format numbers for display *as exactly as the data permits*.
+//      No artificial rounding to "natural fiat decimals" — if the
+//      ledger says 15,847.83 UYU, the dashboard shows 15,847.83 UYU.
+//      Trailing zeros are still trimmed so that an exactly-200 USD
+//      value renders as "200 USD", not "200.00 USD".
 //
 // Pure functions only — safe to import from controllers, Svelte
 // components, query factories, or unit tests.
 
 export interface CurrencyPrecision {
-    /** Decimal places to render in the UI for "ordinary" magnitudes (>= 1). */
-    display: number;
-    /**
-     * Minimum decimal places to render — controls trailing-zero behaviour.
-     * Fiat with cents convention (USD, EUR, …) defaults to `display` so
-     * "780.90" stays "780.90" and not "780.9". Crypto and integer fiat
-     * default to 0 so trailing zeros are trimmed. Defaults to 0 if absent.
-     */
-    minDisplay?: number;
     /** Decimal places to round to in BQL `round(..., n)` so we don't lose information server-side. */
     storage: number;
-    /**
-     * Optional cap on the number of decimals when adapting precision
-     * for sub-unit magnitudes (|value| < 1). Defaults to `storage`
-     * (we never show more decimals than we kept around). Currencies
-     * with a true sub-unit (like satoshis on BTC) accept higher caps.
-     */
-    adaptiveMax?: number;
 }
 
+/**
+ * Per-currency BQL storage precision. We default to 8 (matches the
+ * smallest sub-unit of BTC/ETH and is plenty for any fiat). Currencies
+ * with traditionally finer denominations override upward.
+ */
 const PRECISION_TABLE: Record<string, CurrencyPrecision> = {
-    // --- Cryptocurrencies (smallest-unit-defined) ---
-    BTC: { display: 8, storage: 8, adaptiveMax: 8 },
-    ETH: { display: 8, storage: 8, adaptiveMax: 8 },
-    XMR: { display: 8, storage: 8, adaptiveMax: 8 },
-    LTC: { display: 8, storage: 8, adaptiveMax: 8 },
-    BCH: { display: 8, storage: 8, adaptiveMax: 8 },
-    DOGE: { display: 8, storage: 8, adaptiveMax: 8 },
-    SOL: { display: 6, storage: 8, adaptiveMax: 8 },
-    ADA: { display: 6, storage: 8, adaptiveMax: 8 },
-    DOT: { display: 6, storage: 8, adaptiveMax: 8 },
-
-    // --- Tokenised commodities ---
-    PAXG: { display: 4, storage: 6, adaptiveMax: 8 },
-    XAU:  { display: 4, storage: 6, adaptiveMax: 8 },
-    XAG:  { display: 3, storage: 4, adaptiveMax: 6 },
-
-    // --- "Hundredth-of-unit" fiat: enforce 2 decimals so "780.90" doesn't
-    //     collapse to "780.9". minDisplay = display = 2.
-    USD: { display: 2, minDisplay: 2, storage: 2 },
-    EUR: { display: 2, minDisplay: 2, storage: 2 },
-    GBP: { display: 2, minDisplay: 2, storage: 2 },
-    INR: { display: 2, minDisplay: 2, storage: 2 },
-    BRL: { display: 2, minDisplay: 2, storage: 2 },
-    CAD: { display: 2, minDisplay: 2, storage: 2 },
-    AUD: { display: 2, minDisplay: 2, storage: 2 },
-    CHF: { display: 2, minDisplay: 2, storage: 2 },
-    MXN: { display: 2, minDisplay: 2, storage: 2 },
-    ARS: { display: 2, minDisplay: 2, storage: 2 },
-
-    // --- Effectively-integer fiat (centavo / sen / fil exists in law,
-    //     not in daily circulation; rounding to whole units matches
-    //     how amounts are quoted at point of sale). ---
-    UYU: { display: 0, storage: 2, adaptiveMax: 2 },
-    JPY: { display: 0, storage: 0 },
-    KRW: { display: 0, storage: 0 },
-    VND: { display: 0, storage: 0 },
-    IDR: { display: 0, storage: 0 },
-    CLP: { display: 0, storage: 0 },
-    PYG: { display: 0, storage: 0 },
-    HUF: { display: 0, storage: 0 },
-    TWD: { display: 0, storage: 0 },
+    BTC: { storage: 8 },
+    ETH: { storage: 10 },
+    XMR: { storage: 8 },
+    LTC: { storage: 8 },
+    BCH: { storage: 8 },
+    DOGE: { storage: 8 },
+    SOL: { storage: 9 },
+    ADA: { storage: 8 },
+    DOT: { storage: 10 },
+    PAXG: { storage: 8 },
+    XAU:  { storage: 8 },
+    XAG:  { storage: 6 },
 };
 
-const DEFAULT_PRECISION: CurrencyPrecision = { display: 2, minDisplay: 2, storage: 2 };
+const DEFAULT_PRECISION: CurrencyPrecision = { storage: 8 };
 
 /**
- * Resolve the natural precision for a currency code. Unknown codes
- * fall back to the same 2-decimal default that web banking, fintech
- * and most fiat currencies share.
+ * Resolve the BQL storage precision for a currency code. Unknown codes
+ * default to 8 decimals — enough to faithfully represent any modern
+ * fiat (which max out at thousandths) and BTC-like crypto.
  */
 export function getCurrencyPrecision(code: string | null | undefined): CurrencyPrecision {
     if (!code) return DEFAULT_PRECISION;
     return PRECISION_TABLE[code.toUpperCase()] ?? DEFAULT_PRECISION;
 }
 
-/**
- * Pick the number of decimals to show for `value` in `currency`.
- * Logic:
- *   - For |value| >= 1 → use the currency's display precision.
- *   - For 0 < |value| < 1 → step up the precision (toward
- *     adaptiveMax) so the value retains at least one significant digit.
- *   - For 0 → use display precision (typically 0 or 2).
- *
- * This matches the EquivalentsRow algorithm but parametrised by
- * currency (so 0.012 BTC stays "0.012" while 0.01 USD stays "0.01"
- * and 0 UYU stays just "0").
- */
-function pickDecimals(value: number, p: CurrencyPrecision): number {
-    if (!isFinite(value)) return p.display;
-    const abs = Math.abs(value);
-    const cap = p.adaptiveMax ?? p.storage;
-    const display = p.display;
-
-    if (abs === 0) return display;
-    if (abs >= 1) return display;
-
-    // Sub-unit value: bump decimals until at least one significant digit
-    // shows, capped at `cap`.
-    if (cap <= display) return display;
-    if (abs >= 0.1) return Math.max(display, Math.min(2, cap));
-    if (abs >= 0.01) return Math.max(display, Math.min(4, cap));
-    if (abs >= 0.0001) return Math.max(display, Math.min(6, cap));
-    return cap;
-}
+/** Cap on how many decimals we render — large enough for any realistic case, small enough to dodge floating-point noise. */
+const MAX_DISPLAY_DECIMALS = 10;
 
 /**
- * Format `value` for `currency`. Returns the bare number string
- * (no currency suffix). Trailing zeros are stripped because we
- * pass `minimumFractionDigits: 0` — keeping `1234.5` as `"1,234.5"`
- * rather than `"1,234.50"` for crypto-shaped values.
+ * Format `value` exactly: locale-aware thousands separator, trailing
+ * zeros trimmed, but every real digit preserved. The currency arg is
+ * accepted for API symmetry with `formatCurrencyAmount` but does not
+ * change the precision — we trust the data over a per-currency table.
  */
 export function formatCurrency(
     value: number | null | undefined,
-    currency: string | null | undefined,
+    _currency?: string | null,
     opts: { signed?: boolean; minDigits?: number } = {},
 ): string {
     if (value === null || value === undefined || !isFinite(value)) return '—';
-    const p = getCurrencyPrecision(currency);
-    const max = pickDecimals(value, p);
-    const defaultMin = p.minDisplay ?? 0;
-    const min = Math.max(0, Math.min(max, opts.minDigits ?? defaultMin));
+    const min = Math.max(0, Math.min(MAX_DISPLAY_DECIMALS, opts.minDigits ?? 0));
     const formatted = value.toLocaleString(undefined, {
         minimumFractionDigits: min,
-        maximumFractionDigits: max,
+        maximumFractionDigits: MAX_DISPLAY_DECIMALS,
     });
     return opts.signed && value > 0 ? `+${formatted}` : formatted;
 }

--- a/src/utils/currency-precision.ts
+++ b/src/utils/currency-precision.ts
@@ -17,6 +17,13 @@
 export interface CurrencyPrecision {
     /** Decimal places to render in the UI for "ordinary" magnitudes (>= 1). */
     display: number;
+    /**
+     * Minimum decimal places to render — controls trailing-zero behaviour.
+     * Fiat with cents convention (USD, EUR, …) defaults to `display` so
+     * "780.90" stays "780.90" and not "780.9". Crypto and integer fiat
+     * default to 0 so trailing zeros are trimmed. Defaults to 0 if absent.
+     */
+    minDisplay?: number;
     /** Decimal places to round to in BQL `round(..., n)` so we don't lose information server-side. */
     storage: number;
     /**
@@ -45,17 +52,18 @@ const PRECISION_TABLE: Record<string, CurrencyPrecision> = {
     XAU:  { display: 4, storage: 6, adaptiveMax: 8 },
     XAG:  { display: 3, storage: 4, adaptiveMax: 6 },
 
-    // --- "Hundredth-of-unit" fiat ---
-    USD: { display: 2, storage: 2 },
-    EUR: { display: 2, storage: 2 },
-    GBP: { display: 2, storage: 2 },
-    INR: { display: 2, storage: 2 },
-    BRL: { display: 2, storage: 2 },
-    CAD: { display: 2, storage: 2 },
-    AUD: { display: 2, storage: 2 },
-    CHF: { display: 2, storage: 2 },
-    MXN: { display: 2, storage: 2 },
-    ARS: { display: 2, storage: 2 },
+    // --- "Hundredth-of-unit" fiat: enforce 2 decimals so "780.90" doesn't
+    //     collapse to "780.9". minDisplay = display = 2.
+    USD: { display: 2, minDisplay: 2, storage: 2 },
+    EUR: { display: 2, minDisplay: 2, storage: 2 },
+    GBP: { display: 2, minDisplay: 2, storage: 2 },
+    INR: { display: 2, minDisplay: 2, storage: 2 },
+    BRL: { display: 2, minDisplay: 2, storage: 2 },
+    CAD: { display: 2, minDisplay: 2, storage: 2 },
+    AUD: { display: 2, minDisplay: 2, storage: 2 },
+    CHF: { display: 2, minDisplay: 2, storage: 2 },
+    MXN: { display: 2, minDisplay: 2, storage: 2 },
+    ARS: { display: 2, minDisplay: 2, storage: 2 },
 
     // --- Effectively-integer fiat (centavo / sen / fil exists in law,
     //     not in daily circulation; rounding to whole units matches
@@ -71,7 +79,7 @@ const PRECISION_TABLE: Record<string, CurrencyPrecision> = {
     TWD: { display: 0, storage: 0 },
 };
 
-const DEFAULT_PRECISION: CurrencyPrecision = { display: 2, storage: 2 };
+const DEFAULT_PRECISION: CurrencyPrecision = { display: 2, minDisplay: 2, storage: 2 };
 
 /**
  * Resolve the natural precision for a currency code. Unknown codes
@@ -127,7 +135,8 @@ export function formatCurrency(
     if (value === null || value === undefined || !isFinite(value)) return '—';
     const p = getCurrencyPrecision(currency);
     const max = pickDecimals(value, p);
-    const min = Math.max(0, Math.min(max, opts.minDigits ?? 0));
+    const defaultMin = p.minDisplay ?? 0;
+    const min = Math.max(0, Math.min(max, opts.minDigits ?? defaultMin));
     const formatted = value.toLocaleString(undefined, {
         minimumFractionDigits: min,
         maximumFractionDigits: max,

--- a/src/utils/currency-precision.ts
+++ b/src/utils/currency-precision.ts
@@ -1,0 +1,151 @@
+// src/utils/currency-precision.ts
+//
+// Currency-aware number formatting. The dashboard previously rendered
+// every monetary value with a hard-coded 2-decimal toFixed/toLocaleString,
+// which over-rounded crypto (0.012 BTC → "0.01") and added meaningless
+// trailing zeros to currencies that have no fractional unit in real
+// circulation (UYU, JPY).
+//
+// `getCurrencyPrecision` returns the natural decimal places for each
+// currency code. `formatCurrency` formats a number with that precision
+// and an adaptive override for tiny magnitudes so a sub-cent value
+// doesn't collapse to zero on the screen.
+//
+// Pure functions only — safe to import from controllers, Svelte
+// components, query factories, or unit tests.
+
+export interface CurrencyPrecision {
+    /** Decimal places to render in the UI for "ordinary" magnitudes (>= 1). */
+    display: number;
+    /** Decimal places to round to in BQL `round(..., n)` so we don't lose information server-side. */
+    storage: number;
+    /**
+     * Optional cap on the number of decimals when adapting precision
+     * for sub-unit magnitudes (|value| < 1). Defaults to `storage`
+     * (we never show more decimals than we kept around). Currencies
+     * with a true sub-unit (like satoshis on BTC) accept higher caps.
+     */
+    adaptiveMax?: number;
+}
+
+const PRECISION_TABLE: Record<string, CurrencyPrecision> = {
+    // --- Cryptocurrencies (smallest-unit-defined) ---
+    BTC: { display: 8, storage: 8, adaptiveMax: 8 },
+    ETH: { display: 8, storage: 8, adaptiveMax: 8 },
+    XMR: { display: 8, storage: 8, adaptiveMax: 8 },
+    LTC: { display: 8, storage: 8, adaptiveMax: 8 },
+    BCH: { display: 8, storage: 8, adaptiveMax: 8 },
+    DOGE: { display: 8, storage: 8, adaptiveMax: 8 },
+    SOL: { display: 6, storage: 8, adaptiveMax: 8 },
+    ADA: { display: 6, storage: 8, adaptiveMax: 8 },
+    DOT: { display: 6, storage: 8, adaptiveMax: 8 },
+
+    // --- Tokenised commodities ---
+    PAXG: { display: 4, storage: 6, adaptiveMax: 8 },
+    XAU:  { display: 4, storage: 6, adaptiveMax: 8 },
+    XAG:  { display: 3, storage: 4, adaptiveMax: 6 },
+
+    // --- "Hundredth-of-unit" fiat ---
+    USD: { display: 2, storage: 2 },
+    EUR: { display: 2, storage: 2 },
+    GBP: { display: 2, storage: 2 },
+    INR: { display: 2, storage: 2 },
+    BRL: { display: 2, storage: 2 },
+    CAD: { display: 2, storage: 2 },
+    AUD: { display: 2, storage: 2 },
+    CHF: { display: 2, storage: 2 },
+    MXN: { display: 2, storage: 2 },
+    ARS: { display: 2, storage: 2 },
+
+    // --- Effectively-integer fiat (centavo / sen / fil exists in law,
+    //     not in daily circulation; rounding to whole units matches
+    //     how amounts are quoted at point of sale). ---
+    UYU: { display: 0, storage: 2, adaptiveMax: 2 },
+    JPY: { display: 0, storage: 0 },
+    KRW: { display: 0, storage: 0 },
+    VND: { display: 0, storage: 0 },
+    IDR: { display: 0, storage: 0 },
+    CLP: { display: 0, storage: 0 },
+    PYG: { display: 0, storage: 0 },
+    HUF: { display: 0, storage: 0 },
+    TWD: { display: 0, storage: 0 },
+};
+
+const DEFAULT_PRECISION: CurrencyPrecision = { display: 2, storage: 2 };
+
+/**
+ * Resolve the natural precision for a currency code. Unknown codes
+ * fall back to the same 2-decimal default that web banking, fintech
+ * and most fiat currencies share.
+ */
+export function getCurrencyPrecision(code: string | null | undefined): CurrencyPrecision {
+    if (!code) return DEFAULT_PRECISION;
+    return PRECISION_TABLE[code.toUpperCase()] ?? DEFAULT_PRECISION;
+}
+
+/**
+ * Pick the number of decimals to show for `value` in `currency`.
+ * Logic:
+ *   - For |value| >= 1 → use the currency's display precision.
+ *   - For 0 < |value| < 1 → step up the precision (toward
+ *     adaptiveMax) so the value retains at least one significant digit.
+ *   - For 0 → use display precision (typically 0 or 2).
+ *
+ * This matches the EquivalentsRow algorithm but parametrised by
+ * currency (so 0.012 BTC stays "0.012" while 0.01 USD stays "0.01"
+ * and 0 UYU stays just "0").
+ */
+function pickDecimals(value: number, p: CurrencyPrecision): number {
+    if (!isFinite(value)) return p.display;
+    const abs = Math.abs(value);
+    const cap = p.adaptiveMax ?? p.storage;
+    const display = p.display;
+
+    if (abs === 0) return display;
+    if (abs >= 1) return display;
+
+    // Sub-unit value: bump decimals until at least one significant digit
+    // shows, capped at `cap`.
+    if (cap <= display) return display;
+    if (abs >= 0.1) return Math.max(display, Math.min(2, cap));
+    if (abs >= 0.01) return Math.max(display, Math.min(4, cap));
+    if (abs >= 0.0001) return Math.max(display, Math.min(6, cap));
+    return cap;
+}
+
+/**
+ * Format `value` for `currency`. Returns the bare number string
+ * (no currency suffix). Trailing zeros are stripped because we
+ * pass `minimumFractionDigits: 0` — keeping `1234.5` as `"1,234.5"`
+ * rather than `"1,234.50"` for crypto-shaped values.
+ */
+export function formatCurrency(
+    value: number | null | undefined,
+    currency: string | null | undefined,
+    opts: { signed?: boolean; minDigits?: number } = {},
+): string {
+    if (value === null || value === undefined || !isFinite(value)) return '—';
+    const p = getCurrencyPrecision(currency);
+    const max = pickDecimals(value, p);
+    const min = Math.max(0, Math.min(max, opts.minDigits ?? 0));
+    const formatted = value.toLocaleString(undefined, {
+        minimumFractionDigits: min,
+        maximumFractionDigits: max,
+    });
+    return opts.signed && value > 0 ? `+${formatted}` : formatted;
+}
+
+/**
+ * Format `value` and append the currency suffix. Convenience wrapper
+ * for the common "amount + currency" rendering used everywhere on
+ * the dashboard.
+ */
+export function formatCurrencyAmount(
+    value: number | null | undefined,
+    currency: string | null | undefined,
+    opts: { signed?: boolean; minDigits?: number } = {},
+): string {
+    const num = formatCurrency(value, currency, opts);
+    if (num === '—') return '—';
+    return currency ? `${num} ${currency}` : num;
+}


### PR DESCRIPTION
## Summary

Two related improvements stacked on **#129** (Liabilities & Receivables tab):

1. A **currency-aware precision helper** that replaces hard-coded 2-decimal formatting across the dashboard. Crypto stops collapsing to 2 decimals, hundredth-fiat keeps its trailing zeros, and integer fiat (UYU/JPY/CLP/…) stops showing meaningless `.00`.
2. A **Liabilities tab UX overhaul** that uses the new helper plus several actionability improvements: currency-grouped totals, sort by next-due ascending, search filter, and visual urgency borders.

Sits on top of #129 — merge order should be 129 → this.

## Currency precision

New `src/utils/currency-precision.ts` with a per-currency table and two functions:

- `getCurrencyPrecision(code)` returns `{ display, minDisplay?, storage, adaptiveMax? }`.
- `formatCurrency(value, code, opts?)` and `formatCurrencyAmount(value, code, opts?)` pick the right decimals adaptively, with `minDisplay` enforcing trailing zeros for hundredth-fiat (USD/EUR/GBP/INR/BRL/CAD/AUD/CHF/MXN/ARS), 0 for integer fiat (UYU/JPY/KRW/CLP/PYG/HUF/TWD/VND/IDR), and adaptive precision (up to 8 decimals) for crypto (BTC/ETH/XMR/LTC/BCH/DOGE/SOL/ADA/DOT) and tokenised metals (PAXG/XAU/XAG).

Applied at:
- `OverviewController` KPI strings — also raises BQL `round(..., n)` precision from a hard-coded 2 to the operating-currency's storage value.
- `IncomeStatementTab` section totals + net profit.
- `CommoditiesController.currentPrice` — re-formats from the BQL value via `formatCurrencyAmount`. Price-data query default rounding bumped from 2 to 8 so non-fiat operating currencies don't lose precision.
- `CommodityCard` operating-currency-equivalent label (the holdings sub-row).
- `LiabilitiesController.formatBalance` and `LiabilitiesTab` everywhere.

## Liabilities & Receivables UX

- **Currency-grouped totals** replace the single "Total liabilities / Total receivables" KPIs. The previous tile summed currentBalance across mixed currencies (mathematically meaningless if the user holds a USD card and a UYU card). Now: one tile per (role, currency) pair: e.g. "Liabilities (USD): -1,500.00 USD" and "Liabilities (UYU): -50,000 UYU".
- **Sort cards by next-due ascending** so the most urgent items surface first. Accounts without `due-day` sort to the end. Ties break on account name.
- **Filter input** at the top filters by account path, loan-type, or counterparty (case-insensitive substring). Section headers show "N of total" while a filter is active.
- **Visual urgency** on each card:
  - Overdue → strong red border + inset bar.
  - Due within 7 days → orange inset bar.
  - Otherwise → neutral role-coloured left border (red for liabilities, green for receivables).
- **Above-principal** state: when `|currentBalance|` exceeds `|principal|`, the card tints subtly red and the payoff bar shows `+15% above principal` instead of clamping silently to `100% paid off`.
- **Refresh button** styled to match Income Statement / Overview (icon + label + spin animation).
- **Account name** truncates with ellipsis on narrow cards; the "↗" jump-to-source button moves inline with the name so it stays discoverable.
- **Percent display** trims trailing zeros (`29.50` → `29.5%`, `29.00` → `29%`).
- **Empty state** lists *all* recognised metadata keys (including `funding-account` from #130) and the auto-detection rules.

## Test plan

- [x] UYU value `31423.85` renders as `"31,424 UYU"` (integer fiat).
- [x] USD value `780.94` renders as `"780.94 USD"` (forces 2 trailing zeros).
- [x] BTC value `0.012` renders as `"0.012 BTC"` (no over-rounding).
- [x] Income Statement, Commodity cards, Equivalents row, Liabilities cards all use the new helper.
- [x] Liabilities tab smoke-tested with a synthetic test set (1× UYU credit-card, 1× USD personal-loan, 1× UYU receivable): cards sort 2d → 7d → 12d, orange urgency border on the two due-soon, green role border on the receivable, currency-grouped totals tiles, search filter narrows correctly.
- [x] `Refresh` button shows the spinner during reload, disabled while loading.

## Dependency

Stacks on **#129** (Liabilities & Receivables tab). Merge order: 129 → this.