### PR TITLE
fix(balances): show opened accounts even when they have no postings

### DIFF
--- a/src/controllers/BalanceSheetController.ts
+++ b/src/controllers/BalanceSheetController.ts
@@ -5,6 +5,7 @@ import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
 import { parse as parseCsv } from 'csv-parse/sync';
 import { extractConvertedAmount, extractNonReportingCurrencies, parseAmount } from '../utils/index';
+import { getOpenAccounts } from '../utils/accounts';
 import type { ChartConfiguration } from 'chart.js/auto';
 import { Logger } from '../utils/logger';
 
@@ -413,10 +414,12 @@ export class BalanceSheetController {
 			let tempEquity: [string, string][] = [];
 			let hasUnconvertedCommodities = false;
 			const unconvertedAccounts: string[] = [];
+			const seenAccounts = new Set<string>();
 
 			for (const row of rows) {
 				if (row.length < 2) continue;
 				const [account, amountStr] = row;
+				seenAccounts.add(account);
 
 				// Check for multi-currency results (only relevant for convert method)
 				if (valuationMethod === 'convert' && amountStr.includes(',')) {
@@ -431,6 +434,25 @@ export class BalanceSheetController {
 				} else if (account.startsWith('Equity')) {
 					tempEquity.push([account, amountStr]);
 				}
+			}
+
+			// `sum(position)` only returns accounts with at least one
+			// posting — so a freshly-opened Liabilities:Treasury (or any
+			// asset/equity account) silently disappears from the balance
+			// sheet until its first transaction. Backfill the gaps from
+			// the chart-of-accounts so opened accounts always show, even
+			// at zero balance.
+			try {
+				const openAccounts = await getOpenAccounts(this.plugin);
+				const zeroAmount = `0.00 ${reportingCurrency}`;
+				for (const acc of openAccounts) {
+					if (seenAccounts.has(acc)) continue;
+					if (acc.startsWith('Assets')) tempAssets.push([acc, zeroAmount]);
+					else if (acc.startsWith('Liabilities')) tempLiab.push([acc, zeroAmount]);
+					else if (acc.startsWith('Equity')) tempEquity.push([acc, zeroAmount]);
+				}
+			} catch (e) {
+				Logger.log('[BalanceSheetController] could not load open accounts list:', e);
 			}
 
 			// Build hierarchical structures

--- a/src/controllers/IncomeStatementController.ts
+++ b/src/controllers/IncomeStatementController.ts
@@ -5,6 +5,7 @@ import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
 import { parse as parseCsv } from 'csv-parse/sync';
 import { extractConvertedAmount, extractNonReportingCurrencies, parseAmount } from '../utils/index';
+import { getOpenAccounts } from '../utils/accounts';
 import type { ChartConfiguration } from 'chart.js/auto';
 import { Logger } from '../utils/logger';
 // Re-export AccountItem so IncomeStatementTab can import from here
@@ -419,10 +420,12 @@ export class IncomeStatementController {
 			let tempExpenses: [string, string][] = [];
 			let hasUnconvertedCommodities = false;
 			const unconvertedAccounts: string[] = [];
+			const seenAccounts = new Set<string>();
 
 			for (const row of rows) {
 				if (row.length < 2) continue;
 				const [account, amountStr] = row;
+				seenAccounts.add(account);
 
 				if (valuationMethod === 'convert' && amountStr.includes(',')) {
 					hasUnconvertedCommodities = true;
@@ -434,6 +437,20 @@ export class IncomeStatementController {
 				} else if (account.startsWith('Expenses')) {
 					tempExpenses.push([account, amountStr]);
 				}
+			}
+
+			// Backfill opened-but-unused Income/Expenses accounts so the
+			// chart of accounts is the source of truth, not the postings.
+			try {
+				const openAccounts = await getOpenAccounts(this.plugin);
+				const zeroAmount = `0.00 ${reportingCurrency}`;
+				for (const acc of openAccounts) {
+					if (seenAccounts.has(acc)) continue;
+					if (acc.startsWith('Income')) tempIncome.push([acc, zeroAmount]);
+					else if (acc.startsWith('Expenses')) tempExpenses.push([acc, zeroAmount]);
+				}
+			} catch (e) {
+				Logger.log('[IncomeStatementController] could not load open accounts list:', e);
 			}
 
 			const incomeHierarchy = this.buildAccountHierarchy(tempIncome, 'Income', valuationMethod);


### PR DESCRIPTION
## Summary

\`SELECT account, sum(position)\` only returns accounts that already have at least one posting. A freshly opened account (\`Liabilities:Treasury\`, \`Expenses:Subscriptions\`, etc.) silently disappears from both the Balance Sheet and the Income Statement until its first transaction — which breaks the mental model that the chart of accounts is the source of truth.

Backfill the gaps after the BQL response by listing every open account via \`getOpenAccounts(plugin)\` and adding a zero-balance row for any matching prefix not already in the result. Done in **both** controllers so Assets/Liabilities/Equity and Income/Expenses behave consistently.

Soft-fail if the auxiliary query errors — we still render whatever the main BQL returned.

## How to reproduce (before fix)

1. \`open Liabilities:Credit:Visa USD\` (no transactions yet).
2. Open the **Accounts & Balances** tab.
3. Notice that Visa is missing from the Liabilities column.

After the fix, the new account appears with a \`0.00 <currency>\` balance.

## Test plan

- [x] User's vault with one zero-balance \`Liabilities:Treasury\`: account now shows under the Liabilities column with \`0.00 UYU\`.
- [x] Existing accounts with non-zero balances are unchanged.
- [x] If \`getOpenAccounts\` itself fails, the rest of the tab still renders.

## Independent of other PRs

This fix doesn't depend on #127–#131 and applies cleanly on top of \`Dev\`. Reviewable on its own.