### PR TITLE
feat(balances): split Receivables into its own column

### DIFF
--- a/src/controllers/BalanceSheetController.ts
+++ b/src/controllers/BalanceSheetController.ts
@@ -38,18 +38,22 @@ export interface BalanceSheetState {
 	isLoading: boolean;
 	/** Error message if loading failed. */
 	error: string | null;
-	/** Tree of Asset accounts. */
+	/** Tree of Asset accounts (excluding Assets:Receivables which split out). */
 	assets: AccountItem[];
 	/** Tree of Liability accounts. */
 	liabilities: AccountItem[];
 	/** Tree of Equity accounts. */
 	equity: AccountItem[];
-	/** Total numeric value of Assets. */
+	/** Tree of Assets:Receivables accounts (money owed to the user). */
+	receivables: AccountItem[];
+	/** Total numeric value of Assets (excluding Receivables). */
 	totalAssets: number;
 	/** Total numeric value of Liabilities. */
 	totalLiabilities: number;
 	/** Total numeric value of Equity. */
 	totalEquity: number;
+	/** Total numeric value of Receivables. */
+	totalReceivables: number;
 	/** The reporting currency used. */
 	currency: string;
 	/** Whether multi-currency entries were detected. */
@@ -91,9 +95,11 @@ export class BalanceSheetController {
 			assets: [],
 			liabilities: [],
 			equity: [],
+			receivables: [],
 			totalAssets: 0,
 			totalLiabilities: 0,
 			totalEquity: 0,
+			totalReceivables: 0,
 			currency: plugin.settings.operatingCurrency || 'USD',
 			hasUnconvertedCommodities: false,
 			unconvertedWarning: null,
@@ -409,6 +415,7 @@ export class BalanceSheetController {
 			const rows = firstRowIsHeader ? records.slice(1) : records;
 
 			let tempAssets: [string, string][] = [];
+			let tempReceivables: [string, string][] = [];
 			let tempLiab: [string, string][] = [];
 			let tempEquity: [string, string][] = [];
 			let hasUnconvertedCommodities = false;
@@ -424,7 +431,12 @@ export class BalanceSheetController {
 					unconvertedAccounts.push(account);
 				}
 
-				if (account.startsWith('Assets')) {
+				// Receivables (money owed *to* the user) split out of the
+				// regular Assets column so the Balance Sheet doesn't fold
+				// loan-shaped accounts into the bank/cash totals.
+				if (account.startsWith('Assets:Receivables')) {
+					tempReceivables.push([account, amountStr]);
+				} else if (account.startsWith('Assets')) {
 					tempAssets.push([account, amountStr]);
 				} else if (account.startsWith('Liabilities')) {
 					tempLiab.push([account, amountStr]);
@@ -435,11 +447,13 @@ export class BalanceSheetController {
 
 			// Build hierarchical structures
 			const assetsHierarchy = this.buildAccountHierarchy(tempAssets, 'Assets', valuationMethod);
+			const receivablesHierarchy = this.buildAccountHierarchy(tempReceivables, 'Assets', valuationMethod);
 			const liabilitiesHierarchy = this.buildAccountHierarchy(tempLiab, 'Liabilities', valuationMethod);
 			const equityHierarchy = this.buildAccountHierarchy(tempEquity, 'Equity', valuationMethod);
 
 			// Calculate totals - always use reporting currency
 			const totalAssets = this.calculateCategoryTotals(assetsHierarchy, reportingCurrency);
+			const totalReceivables = this.calculateCategoryTotals(receivablesHierarchy, reportingCurrency);
 			const totalLiabilities = this.calculateCategoryTotals(liabilitiesHierarchy, reportingCurrency);
 			const totalEquity = this.calculateCategoryTotals(equityHierarchy, reportingCurrency);
 
@@ -456,9 +470,11 @@ export class BalanceSheetController {
 				isLoading: false,
 				error: null,
 				assets: this.flattenHierarchy(assetsHierarchy),
+				receivables: this.flattenHierarchy(receivablesHierarchy),
 				liabilities: this.flattenHierarchy(liabilitiesHierarchy),
 				equity: this.flattenHierarchy(equityHierarchy),
 				totalAssets,
+				totalReceivables,
 				totalLiabilities,
 				totalEquity,
 				currency: reportingCurrency,

--- a/src/ui/partials/dashboard/BalanceSheetTab.svelte
+++ b/src/ui/partials/dashboard/BalanceSheetTab.svelte
@@ -17,8 +17,8 @@
 
 	// --- Set up a placeholder and subscribe to the store ---
 	const placeholderState: Writable<BalanceSheetState> = writable({
-		isLoading: true, error: null, assets: [], liabilities: [], equity: [],
-		totalAssets: 0, totalLiabilities: 0, totalEquity: 0, currency: 'INR',
+		isLoading: true, error: null, assets: [], liabilities: [], equity: [], receivables: [],
+		totalAssets: 0, totalLiabilities: 0, totalEquity: 0, totalReceivables: 0, currency: 'INR',
 		hasUnconvertedCommodities: false, unconvertedWarning: null, valuationMethod: 'convert',
 		chartConfig: null, chartError: null, chartLoading: false, chartInterval: 'month'
 	});
@@ -45,8 +45,9 @@
 	}
 
 	// Always show other currencies column for all valuation methods if any section has them
-	$: showOtherCurrenciesColumn = state.assets && state.liabilities && state.equity && 
-		(hasOtherCurrencies(state.assets) || hasOtherCurrencies(state.liabilities) || hasOtherCurrencies(state.equity));
+	$: showOtherCurrenciesColumn = !!state.assets && !!state.liabilities && !!state.equity &&
+		(hasOtherCurrencies(state.assets) || hasOtherCurrencies(state.liabilities) || hasOtherCurrencies(state.equity) ||
+			(!!state.receivables && hasOtherCurrencies(state.receivables)));
 
 	// Handle valuation method change
 	async function handleValuationMethodChange(event: Event) {
@@ -108,6 +109,7 @@
 	$: visibleAssets = state.assets ? state.assets.filter(item => shouldShowRow(item, collapsedAccounts)) : [];
 	$: visibleLiabilities = state.liabilities ? state.liabilities.filter(item => shouldShowRow(item, collapsedAccounts)) : [];
 	$: visibleEquity = state.equity ? state.equity.filter(item => shouldShowRow(item, collapsedAccounts)) : [];
+	$: visibleReceivables = state.receivables ? state.receivables.filter(item => shouldShowRow(item, collapsedAccounts)) : [];
 
 	// Account management functions
 	function handleOpenAccount() {
@@ -345,8 +347,8 @@
 				<tbody>
 					{#each visibleAssets as item}
 						<tr class={getAccountClass(item)}>
-							<td class="account-name" 
-								on:click={(e) => item.isCategory && toggleCollapse(item.account, e)} 
+							<td class="account-name"
+								on:click={(e) => item.isCategory && toggleCollapse(item.account, e)}
 								style="cursor: {item.isCategory ? 'pointer' : 'default'};">
 								{#if item.isCategory}
 									<span class="collapse-icon">{isCollapsed(item.account) ? '▶' : '▼'}</span>
@@ -367,6 +369,45 @@
 				</table>
 			</div>
 
+			{#if visibleReceivables.length > 0}
+				<div class="column">
+					<h4>Receivables</h4>
+					<table class="beancount-table">
+						<thead>
+							<tr class="header-row">
+								<th class="account-header">Account</th>
+								<th class="amount-header">{state.currency}</th>
+								{#if showOtherCurrenciesColumn}
+									<th class="other-currencies-header">Other Currencies</th>
+								{/if}
+							</tr>
+						</thead>
+					<tbody>
+						{#each visibleReceivables as item}
+							<tr class={getAccountClass(item)}>
+								<td class="account-name"
+									on:click={(e) => item.isCategory && toggleCollapse(item.account, e)}
+									style="cursor: {item.isCategory ? 'pointer' : 'default'};">
+									{#if item.isCategory}
+										<span class="collapse-icon">{isCollapsed(item.account) ? '▶' : '▼'}</span>
+									{/if}
+									{getIndentation(item.level)}{item.displayName}
+								</td>
+									<td class="align-right amount-cell" class:category-amount={item.isCategory}>
+										{item.amount}
+									</td>
+									{#if showOtherCurrenciesColumn}
+										<td class="align-right other-currencies-cell">
+											{item.otherCurrencies || ''}
+										</td>
+									{/if}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+
 			<div class="column">
 				<h4>Liabilities</h4>
 				<table class="beancount-table">
@@ -382,8 +423,8 @@
 				<tbody>
 					{#each visibleLiabilities as item}
 						<tr class={getAccountClass(item)}>
-							<td class="account-name" 
-								on:click={(e) => item.isCategory && toggleCollapse(item.account, e)} 
+							<td class="account-name"
+								on:click={(e) => item.isCategory && toggleCollapse(item.account, e)}
 								style="cursor: {item.isCategory ? 'pointer' : 'default'};">
 								{#if item.isCategory}
 									<span class="collapse-icon">{isCollapsed(item.account) ? '▶' : '▼'}</span>
@@ -419,8 +460,8 @@
 				<tbody>
 					{#each visibleEquity as item}
 						<tr class={getAccountClass(item)}>
-							<td class="account-name" 
-								on:click={(e) => item.isCategory && toggleCollapse(item.account, e)} 
+							<td class="account-name"
+								on:click={(e) => item.isCategory && toggleCollapse(item.account, e)}
 								style="cursor: {item.isCategory ? 'pointer' : 'default'};">
 								{#if item.isCategory}
 									<span class="collapse-icon">{isCollapsed(item.account) ? '▶' : '▼'}</span>


### PR DESCRIPTION
## Summary

\`Assets:Receivables:*\` accounts (money owed *to* the user) used to be folded into the Assets column on the Balance Sheet, mixing loans-given-out with bank, cash and crypto holdings. Surface them as a fourth section between Assets and Liabilities, matching how the **Liabilities & Receivables** tab already treats them as their own role.

\`BalanceSheetState\` gains \`receivables: AccountItem[]\` and \`totalReceivables: number\`. The controller's \`loadData\` splits \`Assets:Receivables\` rows out before building hierarchies. The tab renders the new column **conditionally** — when no receivables exist the layout falls back to the original 3-column shape, so vaults without that pattern see no UI churn.

## How to verify

1. Open \`Assets:Receivables:Maria UYU\` (or any \`Assets:Receivables:*\` account).
2. Open the **Accounts & Balances** tab.
3. The new "Receivables" column appears between Assets and Liabilities, listing the matching accounts with their balances. The Assets column no longer includes them.

## Independent of other PRs

Applies cleanly on top of \`Dev\` and doesn't depend on #127–#132. Reviewable on its own.