### PR TITLE
ci: add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release Obsidian Plugin
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - name: Build plugin
+        run: |
+          npm install
+          npm run build
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+
+          gh release create "$tag" \
+            --title="$tag" \
+            --draft \
+            main.js manifest.json styles.css


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the release process for the Obsidian Plugin. Now, whenever a new tag is pushed to the repository, the workflow will build the plugin and create a draft release with the relevant build artifacts.

**Release automation:**

* Introduced a new workflow file `.github/workflows/release.yml` that triggers on tag pushes, builds the plugin using Node.js, and creates a draft GitHub release containing `main.js`, `manifest.json`, and `styles.css`.