### PR TITLE
Add caution note for breaking changes in 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Caution
+- Recent release 1.4.0 has breaking changes for Beta testers (BRAT). I had to change the plugin name and id to make sure obsidian allows submission to community store. This does not work well with BRAT users. If you are using this plugin via BRAT, please reinstall it from BRAT settings. This will not affect existing beancount files.
+- The plugin is now available in community store at `https://community.obsidian.md/plugins/beancount-finance`
+
+-------------------------------------------------
+
 # Beancount Ledger
 
 ![Plugin Logo](docs/assets/Primary_horizontal_logo.png)


### PR DESCRIPTION
Added caution note regarding breaking changes in release 1.4.0 for Beta testers and provided installation instructions.
