### PR TITLE
feat: register .beancount/.bean files with a custom plain-text view (#155)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 import { Plugin } from 'obsidian';
 import { BeancountSettingTab, type BeancountPluginSettings, DEFAULT_SETTINGS } from './settings';
 import { BeancountView, BEANCOUNT_VIEW_TYPE } from './ui/views/sidebar/sidebar-view';
+import { BeancountFileView, BEANCOUNT_FILE_VIEW_TYPE } from './ui/views/beancount-file-view';
 import { UnifiedTransactionModal } from './ui/modals/UnifiedTransactionModal';
 import { runQuery, type BQLFormat } from './utils/index';
 import { createPluginApi, type BeancountPluginApi } from './api';
@@ -77,10 +78,13 @@ export default class BeancountPlugin extends Plugin {
 			UNIFIED_DASHBOARD_VIEW_TYPE,
 			(leaf) => new UnifiedDashboardView(leaf, this)
 		);
+		this.registerView(
+			BEANCOUNT_FILE_VIEW_TYPE,
+			(leaf) => new BeancountFileView(leaf)
+		);
 
-		// Register file extensions so Obsidian shows .beancount and .bean files in file explorer
-		// Note: Uses 'markdown' view type, so Beancount syntax will have some Markdown rendering
-		this.registerExtensions(['beancount', 'bean'], 'markdown');
+		// Register .beancount and .bean files with a plain-text view to avoid Markdown rendering
+		this.registerExtensions(['beancount', 'bean'], BEANCOUNT_FILE_VIEW_TYPE);
 
 		// Add Ribbon Icons
 		this.addRibbonIcon('plus-circle', 'Add Transaction', () => {

--- a/src/ui/views/beancount-file-view.ts
+++ b/src/ui/views/beancount-file-view.ts
@@ -1,0 +1,65 @@
+// src/ui/views/beancount-file-view.ts
+import { TextFileView, WorkspaceLeaf } from 'obsidian';
+
+export const BEANCOUNT_FILE_VIEW_TYPE = 'beancount-file';
+
+/**
+ * A plain-text editor view for .beancount and .bean files.
+ * Extends TextFileView to avoid Obsidian's Markdown rendering pipeline,
+ * so Beancount syntax (*, ;, dates, account names) is never misinterpreted
+ * as Markdown.
+ */
+export class BeancountFileView extends TextFileView {
+	private textarea: HTMLTextAreaElement;
+
+	constructor(leaf: WorkspaceLeaf) {
+		super(leaf);
+	}
+
+	getViewType(): string {
+		return BEANCOUNT_FILE_VIEW_TYPE;
+	}
+
+	getDisplayText(): string {
+		return this.file?.basename ?? 'Beancount File';
+	}
+
+	getIcon(): string {
+		return 'landmark';
+	}
+
+	async onOpen(): Promise<void> {
+		this.contentEl.empty();
+		this.contentEl.addClass('beancount-file-view');
+
+		this.textarea = this.contentEl.createEl('textarea', {
+			cls: 'beancount-editor'
+		});
+
+		this.textarea.addEventListener('input', () => {
+			this.requestSave();
+		});
+	}
+
+	async onClose(): Promise<void> {
+		this.contentEl.empty();
+	}
+
+	/** Called by TextFileView when it needs the current editor content to save. */
+	getViewData(): string {
+		return this.textarea?.value ?? '';
+	}
+
+	/** Called by TextFileView when it loads or reloads the file from disk. */
+	setViewData(data: string, _clear: boolean): void {
+		if (this.textarea) {
+			this.textarea.value = data;
+		}
+	}
+
+	clear(): void {
+		if (this.textarea) {
+			this.textarea.value = '';
+		}
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,30 @@
 /* styles.css */
 
+/* --- Beancount File View --- */
+
+.beancount-file-view {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	padding: 0;
+}
+
+.beancount-editor {
+	flex: 1;
+	width: 100%;
+	height: 100%;
+	resize: none;
+	border: none;
+	outline: none;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-family: var(--font-monospace);
+	font-size: var(--font-text-size);
+	line-height: var(--line-height-normal);
+	padding: var(--size-4-4);
+	box-sizing: border-box;
+}
+
 /* --- BQL Code Block Styles --- */
 
 .bql-query-container {


### PR DESCRIPTION
Previously .beancount and .bean files were registered with Obsidian's built-in 'markdown' view type, causing Markdown rendering to interfere with Beancount syntax (e.g. transaction flags '*' becoming bold, ';' comments not rendering correctly, '---' becoming horizontal rules).

Changes:
- Add BeancountFileView (extends TextFileView) — a textarea-based plain-text editor that bypasses Obsidian's Markdown pipeline entirely. Saves are debounced via requestSave() on every input event.
- Register .beancount and .bean extensions with BEANCOUNT_FILE_VIEW_TYPE instead of 'markdown' in main.ts.
- Add .beancount-file-view / .beancount-editor CSS so the textarea fills the pane with monospace font and respects Obsidian theme variables.

Closes #155