### PR TITLE
Improve atomic file writes and preserve newlines

### DIFF
--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -6,7 +6,7 @@ import { readFile } from 'fs/promises';
 import { parse as parseCsv } from 'csv-parse/sync';
 import type BeancountPlugin from '../main';
 import { getTargetFile, ensureYearFile } from './structuredLayout';
-import { atomicFileWrite, createBackupFile, convertWslPathToWindows } from './fileEditor';
+import { atomicFileWrite, createBackupFile, convertWslPathToWindows, getNewlineCharacter } from './fileEditor';
 import { runQuery } from './queryRunner';
 import { Logger } from './logger';
 
@@ -133,7 +133,9 @@ export async function updateBalance(
         Logger.log(`[updateBalance] ${actualFilePath} → ${normalizedPath}, line ${lineno}`);
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'updateBalance');
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
@@ -142,7 +144,7 @@ export async function updateBalance(
         if (balanceData.tolerance) newBalanceText += ` ~ ${balanceData.tolerance}`;
 
         lines[lineno - 1] = newBalanceText;
-        await atomicFileWrite(normalizedPath, lines.join('\n'));
+        await atomicFileWrite(normalizedPath, lines.join(newline));
         Logger.log(`[updateBalance] Updated ${balanceId}`);
         return { success: true };
     } catch (error) {
@@ -180,13 +182,15 @@ export async function deleteBalance(
         Logger.log(`[deleteBalance] ${actualFilePath} → ${normalizedPath}, line ${lineno}`);
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'deleteBalance');
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
 
         lines.splice(lineno - 1, 1);
-        await atomicFileWrite(normalizedPath, lines.join('\n'));
+        await atomicFileWrite(normalizedPath, lines.join(newline));
         Logger.log(`[deleteBalance] Deleted ${balanceId}`);
         return { success: true };
     } catch (error) {
@@ -259,7 +263,9 @@ export async function updateNote(
         Logger.log(`[updateNote] ${actualFilePath} → ${normalizedPath}, line ${lineno}`);
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'updateNote');
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
@@ -269,7 +275,7 @@ export async function updateNote(
         if (noteData.links) for (const l of noteData.links) noteParts.push(`^${l}`);
 
         lines[lineno - 1] = noteParts.join(' ');
-        await atomicFileWrite(normalizedPath, lines.join('\n'));
+        await atomicFileWrite(normalizedPath, lines.join(newline));
         Logger.log(`[updateNote] Updated ${noteId}`);
         return { success: true };
     } catch (error) {
@@ -307,13 +313,15 @@ export async function deleteNote(
         Logger.log(`[deleteNote] ${actualFilePath} → ${normalizedPath}, line ${lineno}`);
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'deleteNote');
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
 
         lines.splice(lineno - 1, 1);
-        await atomicFileWrite(normalizedPath, lines.join('\n'));
+        await atomicFileWrite(normalizedPath, lines.join(newline));
         Logger.log(`[deleteNote] Deleted ${noteId}`);
         return { success: true };
     } catch (error) {
@@ -370,7 +378,9 @@ export async function saveCommodityMetadata(
         const normalizedPath = convertWslPathToWindows(filename);
         await createBackupFile(normalizedPath, createBackup, 'saveCommodityMetadata');
 
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
@@ -393,7 +403,7 @@ export async function saveCommodityMetadata(
             .map(([key, value]) => `  ${key}: "${value}"`);
 
         lines.splice(lineIndex + 1, endIndex - lineIndex - 1, ...newMetadataLines);
-        await atomicFileWrite(normalizedPath, lines.join('\n'));
+        await atomicFileWrite(normalizedPath, lines.join(newline));
 
         Logger.log(`[saveCommodityMetadata] Saved metadata for ${symbol}`);
         return { success: true };
@@ -413,7 +423,9 @@ export async function deleteCommodityDirective(
         const normalizedPath = convertWslPathToWindows(filename);
         await createBackupFile(normalizedPath, createBackup, 'deleteCommodityDirective');
 
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
@@ -437,7 +449,7 @@ export async function deleteCommodityDirective(
         }
 
         lines.splice(startIndex, endIndex - startIndex);
-        await atomicFileWrite(normalizedPath, lines.join('\n'));
+        await atomicFileWrite(normalizedPath, lines.join(newline));
 
         Logger.log(`[deleteCommodityDirective] Deleted commodity directive for ${symbol}`);
         return { success: true };
@@ -487,7 +499,7 @@ export async function createPriceDirective(
 /**
  * Generates properly formatted Beancount transaction text from a transaction data object.
  */
-export function generateTransactionText(transactionData: any): string {
+export function generateTransactionText(transactionData: any, newline: string = '\n'): string {
     const date = transactionData.date;
     const flag = transactionData.flag || '*';
     const payee = transactionData.payee || '';
@@ -547,7 +559,7 @@ export function generateTransactionText(transactionData: any): string {
         }
     }
 
-    return lines.join('\n');
+    return lines.join(newline);
 }
 
 export async function createTransaction(
@@ -568,7 +580,8 @@ export async function createTransaction(
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'createTransaction');
         const currentContent = await readFile(normalizedPath, 'utf-8');
-        await atomicFileWrite(normalizedPath, currentContent + '\n' + generateTransactionText(transactionData) + '\n');
+        const newline = getNewlineCharacter(currentContent);
+        await atomicFileWrite(normalizedPath, currentContent + newline + generateTransactionText(transactionData, newline) + newline);
 
         Logger.log(`[createTransaction] Created transaction in ${normalizedPath}`);
         return { success: true };
@@ -642,7 +655,8 @@ export async function updateTransaction(
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'updateTransaction');
         const currentContent = await readFile(normalizedPath, 'utf-8');
-        const lines = currentContent.split('\n');
+        const newline = getNewlineCharacter(currentContent);
+        const lines = currentContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
@@ -650,8 +664,8 @@ export async function updateTransaction(
         const { startIndex, endIndex } = findTransactionBlock(lines, lineno - 1);
         Logger.log(`[updateTransaction] Block: lines ${startIndex + 1}–${endIndex + 1}`);
 
-        const newLines = [...lines.slice(0, startIndex), generateTransactionText(transactionData), ...lines.slice(endIndex + 1)];
-        await atomicFileWrite(normalizedPath, newLines.join('\n'));
+        const newLines = [...lines.slice(0, startIndex), generateTransactionText(transactionData, newline), ...lines.slice(endIndex + 1)];
+        await atomicFileWrite(normalizedPath, newLines.join(newline));
         Logger.log(`[updateTransaction] Updated ${transactionId}`);
         return { success: true };
     } catch (error) {
@@ -682,7 +696,8 @@ export async function deleteTransaction(
 
         await createBackupFile(normalizedPath, plugin.settings.createBackups ?? true, 'deleteTransaction');
         const currentContent = await readFile(normalizedPath, 'utf-8');
-        const lines = currentContent.split('\n');
+        const newline = getNewlineCharacter(currentContent);
+        const lines = currentContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };
@@ -693,7 +708,7 @@ export async function deleteTransaction(
 
         Logger.log(`[deleteTransaction] Block: lines ${startIndex + 1}–${endIndex + 1}`);
         const newLines = [...lines.slice(0, startIndex), ...lines.slice(endIndex + 1)];
-        await atomicFileWrite(normalizedPath, newLines.join('\n'));
+        await atomicFileWrite(normalizedPath, newLines.join(newline));
         Logger.log(`[deleteTransaction] Deleted ${transactionId}`);
         return { success: true };
     } catch (error) {
@@ -752,7 +767,9 @@ export async function validateCommodityLocation(
 ): Promise<{ success: boolean; error?: string }> {
     try {
         const normalizedPath = convertWslPathToWindows(filename);
-        const lines = (await readFile(normalizedPath, 'utf-8')).split('\n');
+        const _rawContent = await readFile(normalizedPath, 'utf-8');
+        const newline = getNewlineCharacter(_rawContent);
+        const lines = _rawContent.split(/\r?\n/);
 
         if (isNaN(lineno) || lineno < 1 || lineno > lines.length)
             return { success: false, error: `Invalid line number ${lineno}` };

--- a/src/utils/fileEditor.ts
+++ b/src/utils/fileEditor.ts
@@ -36,22 +36,64 @@ export function convertWslPathToWindows(wslPath: string): string {
  * @param {string} filePath - The target file path to write to.
  * @param {string} content  - The content to write.
  */
-export async function atomicFileWrite(filePath: string, content: string): Promise<void> {
-    const tempPath = `${filePath}.tmp`;
-    await writeFile(tempPath, content, 'utf-8');
 
+/**
+ * Detects the newline character used in a file.
+ * Returns \r\n if CRLF is detected, otherwise \n.
+ */
+export function getNewlineCharacter(content: string): string {
+    return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+
+// Simple async mutex lock to prevent concurrent write collisions on the same file
+class FileLock {
+    private locks = new Map<string, Promise<void>>();
+
+    async acquire(filePath: string): Promise<() => void> {
+        let release: () => void = () => {};
+        const newLock = new Promise<void>(resolve => {
+            release = resolve;
+        });
+
+        const currentLock = this.locks.get(filePath) || Promise.resolve();
+        const nextLock = currentLock.then(() => newLock);
+        this.locks.set(filePath, nextLock);
+
+        await currentLock;
+
+        return () => {
+            if (this.locks.get(filePath) === nextLock) {
+                this.locks.delete(filePath);
+            }
+            release();
+        };
+    }
+}
+
+export const fileLock = new FileLock();
+
+export async function atomicFileWrite(filePath: string, content: string): Promise<void> {
+    const releaseLock = await fileLock.acquire(filePath);
     try {
-        // On Windows, delete the target file before renaming
-        if (existsSync(filePath)) {
-            unlinkSync(filePath);
+        const tempPath = `${filePath}.${Math.random().toString(36).substring(2, 15)}.tmp`;
+        await writeFile(tempPath, content, 'utf-8');
+
+        try {
+            // On Windows, delete the target file before renaming
+            if (existsSync(filePath)) {
+                unlinkSync(filePath);
+            }
+            renameSync(tempPath, filePath);
+        } catch (renameError) {
+            // Fallback: direct overwrite
+            await writeFile(filePath, content, 'utf-8');
+            if (existsSync(tempPath)) {
+                unlinkSync(tempPath);
+            }
         }
-        renameSync(tempPath, filePath);
-    } catch (renameError) {
-        // Fallback: direct overwrite
-        await writeFile(filePath, content, 'utf-8');
-        if (existsSync(tempPath)) {
-            unlinkSync(tempPath);
-        }
+    } finally {
+        releaseLock();
     }
 }
 


### PR DESCRIPTION
This PR improves the robustness of file write operations in the Obsidian plugin by adopting Fava-like safety measures:

1. **Concurrency Control:** Introduced an async mutex lock (`FileLock`) in `src/utils/fileEditor.ts`. Concurrent file write requests to the same path are now queued sequentially, preventing access violations and lost updates. `atomicFileWrite` now generates unique temporary filenames, avoiding race conditions where multiple writes clobber the same `.tmp` file.
2. **Newline Preservation:** The application now actively detects whether a target file uses Windows (`\r\n`) or Unix (`\n`) line endings. File slicing and replacement functions in `src/utils/directives.ts` have been updated to respect and preserve these original newlines, preventing the plugin from forcefully converting the entire ledger file to a specific format.
3. Explicitly skipped Fava's file hash checking per user preference, relying on the lock and atomic renames.

---
*PR created automatically by Jules for task [14418320959047962496](https://jules.google.com/task/14418320959047962496) started by @mkshp-dev*