### PR TITLE
Enhance file write safety with concurrency control and newline preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## In-progress
 - **Accounts and Balances: duplicate "Net Worth Trend" label in trend chart area** — removed the extra chart title rendering so the label appears once in the selector UI.
 - **Commodity metadata: price source test failed for valid expressions on Windows** — switched validation to execute `bean-price -e <source>` using argument-based process spawning (instead of shell-quoted command strings), fixing errors such as invalid source with extra quote characters.
+- **File writes: race conditions and newline corruption on Windows** — adopted Fava-like file-write safety measures across all CRUD operations:
+  - **Concurrency control:** introduced an async mutex (`FileLock`) in `fileEditor.ts`; concurrent writes to the same path are now queued sequentially, and unique temporary filenames eliminate race conditions between parallel `.tmp` writes.
+  - **Newline preservation:** all read-modify-write operations (`updateBalance`, `deleteBalance`, `updateNote`, `deleteNote`, `updateTransaction`, `deleteTransaction`, `saveCommodityMetadata`, `deleteCommodityDirective`) now detect and preserve the file's original line ending (`\r\n` or `\n`) via `getNewlineCharacter()`.
+  - **Append/create operations extended:** `saveOpenDirective`, `saveCloseDirective`, `createBalanceAssertion`, `createNote`, `createCommodity`, and `createPriceDirective` now also detect the target file's line ending before appending, ensuring newly written directives match the file's existing style. (PR #173 + follow-up)
 
 ## [1.5.2] - 2026-05-27
 

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -32,7 +32,8 @@ export async function saveOpenDirective(
 
         await createBackupFile(normalizedPath, createBackup, 'saveOpenDirective');
         const content = await readFile(normalizedPath, 'utf-8');
-        const newContent = content.endsWith('\n') ? `${content}${directiveText}\n` : `${content}\n${directiveText}\n`;
+        const newline = getNewlineCharacter(content);
+        const newContent = content.endsWith(newline) ? `${content}${directiveText}${newline}` : `${content}${newline}${directiveText}${newline}`;
         await atomicFileWrite(normalizedPath, newContent);
 
         Logger.log(`[saveOpenDirective] Saved open directive for ${account}`);
@@ -60,7 +61,8 @@ export async function saveCloseDirective(
 
         await createBackupFile(normalizedPath, createBackup, 'saveCloseDirective');
         const content = await readFile(normalizedPath, 'utf-8');
-        const newContent = content.endsWith('\n') ? `${content}${directiveText}\n` : `${content}\n${directiveText}\n`;
+        const newline = getNewlineCharacter(content);
+        const newContent = content.endsWith(newline) ? `${content}${directiveText}${newline}` : `${content}${newline}${directiveText}${newline}`;
         await atomicFileWrite(normalizedPath, newContent);
 
         Logger.log(`[saveCloseDirective] Saved close directive for ${account}`);
@@ -92,7 +94,8 @@ export async function createBalanceAssertion(
 
         await createBackupFile(normalizedPath, createBackup, 'createBalanceAssertion');
         const content = await readFile(normalizedPath, 'utf-8');
-        const newContent = content.endsWith('\n') ? `${content}${directiveText}\n` : `${content}\n${directiveText}\n`;
+        const newline = getNewlineCharacter(content);
+        const newContent = content.endsWith(newline) ? `${content}${directiveText}${newline}` : `${content}${newline}${directiveText}${newline}`;
         await atomicFileWrite(normalizedPath, newContent);
 
         Logger.log(`[createBalanceAssertion] Saved balance for ${account}`);
@@ -222,7 +225,8 @@ export async function createNote(
 
         await createBackupFile(normalizedPath, createBackup, 'createNote');
         const content = await readFile(normalizedPath, 'utf-8');
-        const newContent = content.endsWith('\n') ? `${content}${directiveText}\n` : `${content}\n${directiveText}\n`;
+        const newline = getNewlineCharacter(content);
+        const newContent = content.endsWith(newline) ? `${content}${directiveText}${newline}` : `${content}${newline}${directiveText}${newline}`;
         await atomicFileWrite(normalizedPath, newContent);
 
         Logger.log(`[createNote] Saved note for ${account}`);
@@ -352,11 +356,12 @@ export async function createCommodity(
         const metadataLines: string[] = [];
         if (priceMetadata) metadataLines.push(`  price: "${priceMetadata}"`);
         if (logoUrl) metadataLines.push(`  logo: "${logoUrl}"`);
-        if (metadataLines.length > 0) directiveText += '\n' + metadataLines.join('\n');
 
         await createBackupFile(normalizedPath, createBackup, 'createCommodity');
         const content = await readFile(normalizedPath, 'utf-8');
-        const newContent = content.endsWith('\n') ? `${content}${directiveText}\n` : `${content}\n${directiveText}\n`;
+        const newline = getNewlineCharacter(content);
+        if (metadataLines.length > 0) directiveText += newline + metadataLines.join(newline);
+        const newContent = content.endsWith(newline) ? `${content}${directiveText}${newline}` : `${content}${newline}${directiveText}${newline}`;
         await atomicFileWrite(normalizedPath, newContent);
 
         Logger.log(`[createCommodity] Created commodity ${symbol}`);
@@ -483,7 +488,8 @@ export async function createPriceDirective(
 
         await createBackupFile(normalizedPath, createBackup, 'createPriceDirective');
         const content = await readFile(normalizedPath, 'utf-8');
-        const newContent = content.endsWith('\n') ? `${content}${directiveText}\n` : `${content}\n${directiveText}\n`;
+        const newline = getNewlineCharacter(content);
+        const newContent = content.endsWith(newline) ? `${content}${directiveText}${newline}` : `${content}${newline}${directiveText}${newline}`;
         await atomicFileWrite(normalizedPath, newContent);
 
         Logger.log(`[createPriceDirective] Created price directive for ${commodity}`);


### PR DESCRIPTION
This pull request addresses file write safety and newline consistency issues, particularly on Windows. It introduces robust concurrency control for file writes and ensures that all append or create operations preserve the original line ending style of the target file. These changes help prevent race conditions and maintain consistent file formatting across different platforms.

**File write safety and consistency:**

* Added an async mutex (`FileLock`) to `fileEditor.ts` to queue concurrent writes to the same file path, eliminating race conditions and ensuring sequential file operations. Unique temporary filenames are now used for atomic writes.
* All read-modify-write operations now detect and preserve the file's original line ending (`\r\n` or `\n`) using `getNewlineCharacter()`. This affects functions like `updateBalance`, `deleteBalance`, `updateNote`, `deleteNote`, `updateTransaction`, `deleteTransaction`, `saveCommodityMetadata`, and `deleteCommodityDirective`.

**Append/create directive consistency:**

* Updated functions (`saveOpenDirective`, `saveCloseDirective`, `createBalanceAssertion`, `createNote`, `createCommodity`, and `createPriceDirective` in `src/utils/directives.ts`) to detect the target file's line ending before appending, ensuring new directives match the existing style. 
* In `createCommodity`, metadata lines now use the detected newline character, preserving consistency within multi-line commodity definitions.