### PR TITLE
fix: Correct settings update order in migrateToStructuredLayout

### DIFF
--- a/src/utils/structuredLayout.ts
+++ b/src/utils/structuredLayout.ts
@@ -649,8 +649,8 @@ export async function migrateToStructuredLayout(
         await writeToFile(plugin, ledgerPath, includeStatements);
 
         // Step 6: Update plugin settings
-        const mainLedgerPath = getMainLedgerPath(plugin);
         plugin.settings.structuredFolderName = targetFolderName;
+        const mainLedgerPath = getMainLedgerPath(plugin);
         plugin.settings.structuredFolderPath = mainLedgerPath;
         plugin.settings.beancountFilePath = mainLedgerPath;
         await plugin.saveSettings();


### PR DESCRIPTION
The order in which `plugin.settings` was updated during `migrateToStructuredLayout` was incorrect. Specifically, `plugin.settings.structuredFolderName` was assigned *after* `getMainLedgerPath` was called. Since `getMainLedgerPath` uses the `structuredFolderName` to build the path, it would generate a path based on the default or previous folder name instead of the user-provided `targetFolderName`. This caused the `beancountFilePath` setting to point to an incorrect path after the onboarding flow completed. 

This commit fixes this by updating `plugin.settings.structuredFolderName = targetFolderName` before generating the main ledger path.

---
*PR created automatically by Jules for task [4995773308781471806](https://jules.google.com/task/4995773308781471806) started by @mkshp-dev*