### PR TITLE
docs: add Obsidian review analysis report

### DIFF
--- a/OBSIDIAN_REVIEW_REPORT.md
+++ b/OBSIDIAN_REVIEW_REPORT.md
@@ -1,0 +1,74 @@
+# Obsidian Plugin Review Analysis Report
+
+This report analyzes the warnings generated during the Obsidian community plugin review process and proposes mitigation strategies or justifications for each.
+
+## 1. Direct Filesystem Access (`fs` module)
+
+### Findings:
+* `src/services/price.service.ts`: Uses `readFile`, `writeFile`, `existsSync`
+* `src/utils/directives.ts`: Uses `readFile`
+* `src/utils/structuredLayout.ts`: Uses `fs`
+* `src/utils/fileEditor.ts`: Uses `writeFile`, `copyFile`, `existsSync`, `unlinkSync`, `renameSync`
+* `src/utils/SystemDetector.ts`: Uses `existsSync`, `accessSync`, `constants`, `access`
+
+### Analysis:
+The `fs` module is currently used extensively for reading and writing Beancount files directly to the filesystem. This was originally implemented to allow users to select a Beancount file located anywhere on their computer, bypassing the Obsidian vault boundary.
+
+### Mitigation/Alternative:
+**Action:** We can completely eliminate this warning by restricting users to keeping their Beancount files **inside** the Obsidian vault.
+**Implementation:**
+* Replace all `fs` read/write operations with the Obsidian Vault API (`app.vault.read`, `app.vault.modify`, `app.vault.adapter.read`, `app.vault.adapter.write`, etc.).
+* Update the settings UI to only allow file selection from within the vault.
+* Provide clear documentation on this limitation and a migration guide for existing users.
+**Importance:** High. Removing `fs` is a strong security improvement in the context of Obsidian plugins.
+
+## 2. Shell Execution (`child_process` module)
+
+### Findings:
+* `src/services/price.service.ts`: Uses `exec`
+* `src/utils/queryRunner.ts`: Uses `exec`
+* `src/utils/validators.ts`: Uses `spawn`
+* `src/utils/SystemDetector.ts`: Uses `exec`
+* `src/ui/views/sidebar/sidebar-view.ts`: Uses `exec`
+
+### Analysis:
+The `child_process` module is used to interface with the Beancount CLI tools (`bean-query`, `bean-check`, etc.) and the underlying Python backend. Because Beancount is a Python package without a pure Javascript/WebAssembly equivalent, invoking these external commands is the core engine of the plugin.
+
+### Mitigation/Alternative:
+**Action:** This warning **cannot be completely eliminated** without removing the core functionality of the plugin. We must justify its use.
+**Implementation:**
+* **Minimize Scope:** Ensure we are only executing specific, expected commands. Review `SystemDetector.ts` to see if shell commands for OS detection can be replaced with Node's built-in `os` module or Obsidian's `Platform` API.
+* **Sanitize Inputs:** Ensure that any user-provided data passed into `exec` or `spawn` is heavily sanitized and parameterized to prevent shell injection vulnerabilities.
+* **Justification:** In our response to the reviewers, we must clearly state that `child_process` is strictly required to run the `beancount` Python package, which is the entire premise of the plugin. We should emphasize that the plugin is essentially a frontend for a local Python process.
+**Importance:** Critical to justify. The plugin cannot function without it.
+
+## 3. Vault Enumeration (`vault.getFiles`, `getMarkdownFiles`)
+
+### Findings:
+* `src/utils/structuredLayout.ts`: Uses `getFiles()`
+* `src/ui/modals/OnboardingModal.ts`: Uses `getFiles()`
+* `src/settings.ts`: Uses `getMarkdownFiles()` (twice)
+
+### Analysis:
+These methods are used to scan the entire vault. `getFiles()` is likely used to automatically discover `.bean` or `.beancount` files. `getMarkdownFiles()` in settings is typically used to populate dropdowns for linking to specific notes.
+
+### Mitigation/Alternative:
+**Action:** Minimize or replace full vault enumeration to improve performance and reduce requested permissions.
+**Implementation:**
+* **Replace `getFiles()` for Beancount files:** Instead of auto-discovering files across the entire vault (which can be very slow in large vaults), require the user to explicitly configure the path to their main Beancount file in the settings, or limit the search to a specific, user-defined subfolder.
+* **Review `getMarkdownFiles()`:** If used for settings dropdowns (e.g., "Select a default note"), consider using Obsidian's built-in fuzzy search UI (`SuggestModal` or `FuzzySuggestModal`) which can be more performant and doesn't require upfront enumeration of all files into memory, or clearly justify that it only runs once when opening settings.
+**Importance:** Medium. Improving this shows good citizenship and care for performance in large vaults.
+
+## 4. Clipboard Access
+
+### Findings:
+* `src/ui/markdown/BQLCodeBlockProcessor.ts`: Uses `navigator.clipboard.writeText(result)`
+
+### Analysis:
+Clipboard access is used specifically to implement a "Copy results to clipboard" button on rendered Beancount Query Language (BQL) code blocks.
+
+### Mitigation/Alternative:
+**Action:** Justify its use. This is a legitimate and standard use case.
+**Implementation:**
+* **Justification:** Explain to the reviewers that clipboard access is strictly limited to a user-initiated action (clicking a 'Copy' button) and that the plugin only **writes** to the clipboard (it does not read from it, which would be a larger privacy concern). This is safe and expected behavior for a code block processor.
+**Importance:** Low. Easy to justify.


### PR DESCRIPTION
This PR addresses the warnings flagged during the Obsidian community plugin review process. 

It adds a comprehensive `OBSIDIAN_REVIEW_REPORT.md` report at the repository root that analyzes the usage of the following flagged APIs:
1.  **Direct Filesystem Access (`fs` module)**
2.  **Shell Execution (`child_process` module)**
3.  **Vault Enumeration (`vault.getFiles`, `getMarkdownFiles`)**
4.  **Clipboard Access (`navigator.clipboard.writeText`)**

For each finding, the report identifies the source files, analyzes the necessity of the code, and details a mitigation strategy (such as replacing `fs` with the `app.vault` API) or provides a justification to be submitted back to the Obsidian plugin reviewers.

**Note on dependencies:** During testing, the `typescript` dev dependency was added to successfully run the `npm run build` command, using `--legacy-peer-deps` to bypass codemirror peer dependency issues. Only the markdown file itself is being committed.

---
*PR created automatically by Jules for task [1498594745069617616](https://jules.google.com/task/1498594745069617616) started by @mkshp-dev*