### PR TITLE
Clarify multi-currency warning column wording

### DIFF
--- a/src/controllers/BalanceSheetController.ts
+++ b/src/controllers/BalanceSheetController.ts
@@ -447,7 +447,7 @@ export class BalanceSheetController {
 			// Create warning message
 			let unconvertedWarning = null;
 			if (hasUnconvertedCommodities) {
-				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the first column, other currencies are displayed separately in the second column. Only ${reportingCurrency} amounts are included in totals.`;
+				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the ${reportingCurrency} column; other currencies are displayed separately. Only ${reportingCurrency} amounts are included in totals.`;
 			}
 
 			const currentState = get(this.state);

--- a/src/controllers/IncomeStatementController.ts
+++ b/src/controllers/IncomeStatementController.ts
@@ -454,7 +454,7 @@ export class IncomeStatementController {
 
 			let unconvertedWarning: string | null = null;
 			if (hasUnconvertedCommodities) {
-				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the first column, other currencies are displayed separately. Only ${reportingCurrency} amounts are included in totals.`;
+				unconvertedWarning = `Multi-currency accounts detected. ${reportingCurrency} amounts are shown in the ${reportingCurrency} column; other currencies are displayed separately. Only ${reportingCurrency} amounts are included in totals.`;
 			}
 
 			const currentState = get(this.state);


### PR DESCRIPTION
## Problem

The Balance Sheet and Income Statement show a warning when `convert(...)` leaves non-reporting currencies in an account balance. That warning is useful, but the current copy describes the display using positional column wording such as `first column` and `second column`.

That can be misleading because the tables also include an Account column, and the extra values are shown in a conditional `Other Currencies` column. In practice, the warning is about which amounts are included in totals, not about a fixed column index.

## Fix

- Refer to the reporting-currency column by currency name instead of saying `first column`.
- Say that other currencies are displayed separately instead of saying they are in the `second column`.
- Keep the existing detection, display, and total calculation behavior unchanged.

Example after the change:

```text
Multi-currency accounts detected. USD amounts are shown in the USD column; other currencies are displayed separately. Only USD amounts are included in totals.
```

## Verification

```bash
npm run build
npm run eslint
```