### PR TITLE
Add selectable period metrics to overview

### DIFF
--- a/src/controllers/OverviewController.ts
+++ b/src/controllers/OverviewController.ts
@@ -60,17 +60,19 @@ export class OverviewController {
 	constructor(plugin: BeancountPlugin) {
 		this.plugin = plugin;
 		const now = new Date();
+		const defaultPreset = this.getDefaultPeriodPreset();
+		const defaultPeriod = this.resolvePresetDate(defaultPreset, now);
 		// Initialize the store with default values
 		this.state = writable({
 			isLoading: true,
 			error: null,
 			netWorth: '0.00 USD',
 			currency: plugin.settings.operatingCurrency || 'USD',
-			periodPreset: 'this-month',
-			periodMode: 'month',
-			periodYear: now.getFullYear(),
-			periodMonth: now.getMonth() + 1,
-			periodLabel: this.formatPeriodLabel('month', now.getFullYear(), now.getMonth() + 1),
+			periodPreset: defaultPreset,
+			periodMode: defaultPeriod.mode,
+			periodYear: defaultPeriod.year,
+			periodMonth: defaultPeriod.month,
+			periodLabel: this.formatPeriodLabel(defaultPeriod.mode, defaultPeriod.year, defaultPeriod.month),
 			periodIncome: '0.00 USD',
 			periodExpenses: '0.00 USD',
 			periodNetIncome: '0.00 USD',
@@ -215,7 +217,7 @@ export class OverviewController {
 	private resolvePresetDate(preset: OverviewPeriodPreset, now: Date) {
 		const year = now.getFullYear();
 		const month = now.getMonth() + 1;
-		const current = get(this.state);
+		const current = this.state ? get(this.state) : { periodYear: year, periodMonth: month };
 
 		switch (preset) {
 			case 'last-month': {
@@ -242,5 +244,13 @@ export class OverviewController {
 
 	private pad2(value: number): string {
 		return String(value).padStart(2, '0');
+	}
+
+	private getDefaultPeriodPreset(): OverviewPeriodPreset {
+		const preset = this.plugin.settings.dashboardDefaultPeriod;
+		if (preset === 'last-month' || preset === 'this-year' || preset === 'last-year') {
+			return preset;
+		}
+		return 'this-month';
 	}
 }

--- a/src/controllers/OverviewController.ts
+++ b/src/controllers/OverviewController.ts
@@ -98,7 +98,7 @@ export class OverviewController {
 		try {
 			const period = this.getPeriodRange();
 			const [netWorthResult, periodIncomeResult, periodExpensesResult, periodSavingsResult] = await Promise.all([
-				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, 2)),
+				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, 2, period.endDate)),
 				this.plugin.runQuery(queries.getPeriodIncomeQuery(reportingCurrency, 2, period.startDate, period.endDate)),
 				this.plugin.runQuery(queries.getPeriodExpensesQuery(reportingCurrency, 2, period.startDate, period.endDate)),
 				this.plugin.runQuery(queries.getPeriodSavingsQuery(reportingCurrency, 2, period.startDate, period.endDate)),

--- a/src/controllers/OverviewController.ts
+++ b/src/controllers/OverviewController.ts
@@ -5,6 +5,9 @@ import type BeancountPlugin from '../main';
 import * as queries from '../queries/index';
 import { Logger } from '../utils/logger';
 
+export type OverviewPeriodMode = 'month' | 'year';
+export type OverviewPeriodPreset = 'this-month' | 'last-month' | 'this-year' | 'last-year' | 'custom-month' | 'custom-year';
+
 /**
  * Interface representing the state of the Overview dashboard.
  */
@@ -15,14 +18,26 @@ export interface OverviewState {
 	error: string | null;
 	/** Net worth string (e.g. "1,000.00 USD"). */
 	netWorth: string;
-	/** Monthly income string. */
-	monthlyIncome: string;
-	/** Monthly expenses string. */
-	monthlyExpenses: string;
-	/** Savings rate percentage string (e.g. "20%"). */
-	savingsRate: string;
 	/** The reporting currency. */
 	currency: string;
+	/** Selected period preset. */
+	periodPreset: OverviewPeriodPreset;
+	/** Selected summary period granularity. */
+	periodMode: OverviewPeriodMode;
+	/** Selected period year. */
+	periodYear: number;
+	/** Selected period month, one-based. */
+	periodMonth: number;
+	/** Human-readable selected period label. */
+	periodLabel: string;
+	/** Period income string. */
+	periodIncome: string;
+	/** Period expenses string. */
+	periodExpenses: string;
+	/** Period net income string. */
+	periodNetIncome: string;
+	/** Period savings rate percentage string. */
+	periodSavingsRate: string;
 }
 
 /**
@@ -44,15 +59,22 @@ export class OverviewController {
 	 */
 	constructor(plugin: BeancountPlugin) {
 		this.plugin = plugin;
+		const now = new Date();
 		// Initialize the store with default values
 		this.state = writable({
 			isLoading: true,
 			error: null,
 			netWorth: '0.00 USD',
-			monthlyIncome: '0.00 USD',
-			monthlyExpenses: '0.00 USD',
-			savingsRate: '0%',
 			currency: plugin.settings.operatingCurrency || 'USD',
+			periodPreset: 'this-month',
+			periodMode: 'month',
+			periodYear: now.getFullYear(),
+			periodMonth: now.getMonth() + 1,
+			periodLabel: this.formatPeriodLabel('month', now.getFullYear(), now.getMonth() + 1),
+			periodIncome: '0.00 USD',
+			periodExpenses: '0.00 USD',
+			periodNetIncome: '0.00 USD',
+			periodSavingsRate: '0%',
 		});
 	}
 
@@ -74,33 +96,24 @@ export class OverviewController {
 		}
 
 		try {
-			const [netWorthResult, incomeResult, expensesResult, savingsResult] = await Promise.all([
+			const period = this.getPeriodRange();
+			const [netWorthResult, periodIncomeResult, periodExpensesResult, periodSavingsResult] = await Promise.all([
 				this.plugin.runQuery(queries.getTotalWorthQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getThisMonthIncomeQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getThisMonthExpensesQuery(reportingCurrency, 2)),
-				this.plugin.runQuery(queries.getThisMonthSavingsQuery(reportingCurrency, 2)),
+				this.plugin.runQuery(queries.getPeriodIncomeQuery(reportingCurrency, 2, period.startDate, period.endDate)),
+				this.plugin.runQuery(queries.getPeriodExpensesQuery(reportingCurrency, 2, period.startDate, period.endDate)),
+				this.plugin.runQuery(queries.getPeriodSavingsQuery(reportingCurrency, 2, period.startDate, period.endDate)),
 			]);
 
 			// Process KPI Data
 			Logger.log("OverviewController: Net Worth Result:", netWorthResult);
-			const parseNumericResult = (csv: string): number => {
-				const lines = csv.split('\n').map(line => line.trim()).filter(Boolean);
-				return parseFloat(lines[1]) || 0;
-			};
-
-			const netWorthNum = parseNumericResult(netWorthResult);
+			const netWorthNum = this.parseNumericResult(netWorthResult);
 			Logger.log("OverviewController: Parsed Net Worth:", netWorthNum);
-
-			const incomeAmount = parseNumericResult(incomeResult);
-			const expensesAmount = parseNumericResult(expensesResult);
-			const savingsNum = parseNumericResult(savingsResult);
 
 			const newState: Partial<OverviewState> = {
 				netWorth: `${netWorthNum.toFixed(2)} ${reportingCurrency}`,
-				monthlyIncome: `${incomeAmount.toFixed(2)} ${reportingCurrency}`,
-				monthlyExpenses: `${expensesAmount.toFixed(2)} ${reportingCurrency}`,
-				savingsRate: incomeAmount > 0 ? `${((savingsNum / incomeAmount) * 100).toFixed(0)}%` : 'N/A',
 				currency: reportingCurrency,
+				periodLabel: period.label,
+				...this.formatPeriodResults(periodIncomeResult, periodExpensesResult, periodSavingsResult, reportingCurrency),
 			};
 
 			// Update the store with KPI data
@@ -111,5 +124,123 @@ export class OverviewController {
 			const errMsg = e instanceof Error ? e.message : String(e);
 			this.state.update(s => ({ ...s, isLoading: false, error: `Failed to load data: ${errMsg}` }));
 		}
+	}
+
+	async setPeriodPreset(preset: OverviewPeriodPreset) {
+		const now = new Date();
+		const selected = this.resolvePresetDate(preset, now);
+
+		this.state.update(s => ({
+			...s,
+			periodPreset: preset,
+			periodMode: selected.mode,
+			periodYear: selected.year,
+			periodMonth: selected.month,
+			periodLabel: this.formatPeriodLabel(selected.mode, selected.year, selected.month),
+		}));
+		await this.loadData();
+	}
+
+	async setPeriodYear(year: number) {
+		const normalizedYear = Number.isFinite(year) ? Math.max(1, Math.trunc(year)) : new Date().getFullYear();
+		this.state.update(s => ({
+			...s,
+			periodYear: normalizedYear,
+			periodLabel: this.formatPeriodLabel(s.periodMode, normalizedYear, s.periodMonth),
+		}));
+		await this.loadData();
+	}
+
+	async setPeriodMonth(month: number) {
+		const normalizedMonth = Number.isFinite(month) ? Math.min(12, Math.max(1, Math.trunc(month))) : new Date().getMonth() + 1;
+		this.state.update(s => ({
+			...s,
+			periodMonth: normalizedMonth,
+			periodLabel: this.formatPeriodLabel(s.periodMode, s.periodYear, normalizedMonth),
+		}));
+		await this.loadData();
+	}
+
+	private getPeriodRange() {
+		const { periodMode, periodYear, periodMonth } = get(this.state);
+		const year = Number.isFinite(periodYear) ? Math.max(1, Math.trunc(periodYear)) : new Date().getFullYear();
+		const month = Number.isFinite(periodMonth) ? Math.min(12, Math.max(1, Math.trunc(periodMonth))) : new Date().getMonth() + 1;
+
+		if (periodMode === 'year') {
+			return {
+				startDate: `${year}-01-01`,
+				endDate: `${year + 1}-01-01`,
+				label: this.formatPeriodLabel(periodMode, year, month),
+			};
+		}
+
+		const nextYear = month === 12 ? year + 1 : year;
+		const nextMonth = month === 12 ? 1 : month + 1;
+		return {
+			startDate: `${year}-${this.pad2(month)}-01`,
+			endDate: `${nextYear}-${this.pad2(nextMonth)}-01`,
+			label: this.formatPeriodLabel(periodMode, year, month),
+		};
+	}
+
+	private formatPeriodLabel(mode: OverviewPeriodMode, year: number, month: number): string {
+		if (mode === 'year') {
+			return `${year}`;
+		}
+		return `${year}-${this.pad2(month)}`;
+	}
+
+	private parseNumericResult(csv: string): number {
+		const lines = csv.split('\n').map(line => line.trim()).filter(Boolean);
+		return parseFloat(lines[1]) || 0;
+	}
+
+	private formatCurrency(amount: number, currency: string): string {
+		return `${amount.toFixed(2)} ${currency}`;
+	}
+
+	private formatPeriodResults(incomeCsv: string, expensesCsv: string, savingsCsv: string, currency: string): Partial<OverviewState> {
+		const incomeAmount = this.parseNumericResult(incomeCsv);
+		const expensesAmount = this.parseNumericResult(expensesCsv);
+		const savingsAmount = this.parseNumericResult(savingsCsv);
+
+		return {
+			periodIncome: this.formatCurrency(incomeAmount, currency),
+			periodExpenses: this.formatCurrency(expensesAmount, currency),
+			periodNetIncome: this.formatCurrency(savingsAmount, currency),
+			periodSavingsRate: incomeAmount > 0 ? `${((savingsAmount / incomeAmount) * 100).toFixed(0)}%` : 'N/A',
+		};
+	}
+
+	private resolvePresetDate(preset: OverviewPeriodPreset, now: Date) {
+		const year = now.getFullYear();
+		const month = now.getMonth() + 1;
+		const current = get(this.state);
+
+		switch (preset) {
+			case 'last-month': {
+				const lastMonthDate = new Date(year, month - 2, 1);
+				return {
+					mode: 'month' as const,
+					year: lastMonthDate.getFullYear(),
+					month: lastMonthDate.getMonth() + 1,
+				};
+			}
+			case 'this-year':
+				return { mode: 'year' as const, year, month };
+			case 'last-year':
+				return { mode: 'year' as const, year: year - 1, month };
+			case 'custom-month':
+				return { mode: 'month' as const, year: current.periodYear, month: current.periodMonth };
+			case 'custom-year':
+				return { mode: 'year' as const, year: current.periodYear, month: current.periodMonth };
+			case 'this-month':
+			default:
+				return { mode: 'month' as const, year, month };
+		}
+	}
+
+	private pad2(value: number): string {
+		return String(value).padStart(2, '0');
 	}
 }

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -45,6 +45,18 @@ export function getThisMonthSavingsQuery(currency: string, rounding: number): st
 	return `SELECT neg(round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding})) AS _thisMonthNetWorthChange WHERE account ~ '^(Income|Expenses)' AND month=month(today()) AND year=year(today())`;
 }
 
+export function getPeriodIncomeQuery(currency: string, rounding: number, startDate: string, endDate: string): string {
+	return `SELECT neg(round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding})) AS _periodIncome WHERE account ~ '^Income' AND date >= ${startDate} AND date < ${endDate}`;
+}
+
+export function getPeriodExpensesQuery(currency: string, rounding: number, startDate: string, endDate: string): string {
+	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding}) AS _periodExpenses WHERE account ~ '^Expenses' AND date >= ${startDate} AND date < ${endDate}`;
+}
+
+export function getPeriodSavingsQuery(currency: string, rounding: number, startDate: string, endDate: string): string {
+	return `SELECT neg(round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding})) AS _periodNetIncome WHERE account ~ '^(Income|Expenses)' AND date >= ${startDate} AND date < ${endDate}`;
+}
+
 export function getBalanceSheetQuery(currency: string): string {
 	return `SELECT account, convert(sum(position), '${currency}') WHERE account ~ '^(Assets|Liabilities|Equity)' AND NOT close_date(account) GROUP BY account ORDER BY account`;
 }

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -20,16 +20,24 @@ export interface TransactionFilters {
 // --- Query Functions ---
 
 
-export function getTotalAssetsQuery(currency: string, rounding: number): string {
-	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding}) AS _totalAssets WHERE account ~ '^Assets'`;
+function valuationDateArgument(asOfDate?: string): string {
+	return asOfDate ? `, ${asOfDate}` : '';
 }
 
-export function getTotalLiabilitiesQuery(currency: string, rounding: number): string {
-	return `SELECT neg(round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding})) AS _totalLiabilities WHERE account ~ '^Liabilities'`;
+function asOfDateClause(asOfDate?: string): string {
+	return asOfDate ? ` AND date < ${asOfDate}` : '';
 }
 
-export function getTotalWorthQuery(currency: string, rounding: number): string {
-	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'))), ${rounding}) AS _totalWorth WHERE account ~ '^(Assets|Liabilities)'`;
+export function getTotalAssetsQuery(currency: string, rounding: number, asOfDate?: string): string {
+	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'${valuationDateArgument(asOfDate)}))), ${rounding}) AS _totalAssets WHERE account ~ '^Assets'${asOfDateClause(asOfDate)}`;
+}
+
+export function getTotalLiabilitiesQuery(currency: string, rounding: number, asOfDate?: string): string {
+	return `SELECT neg(round(number(only('${currency}', convert(sum(position), '${currency}'${valuationDateArgument(asOfDate)}))), ${rounding})) AS _totalLiabilities WHERE account ~ '^Liabilities'${asOfDateClause(asOfDate)}`;
+}
+
+export function getTotalWorthQuery(currency: string, rounding: number, asOfDate?: string): string {
+	return `SELECT round(number(only('${currency}', convert(sum(position), '${currency}'${valuationDateArgument(asOfDate)}))), ${rounding}) AS _totalWorth WHERE account ~ '^(Assets|Liabilities)'${asOfDateClause(asOfDate)}`;
 }
 
 // This Month Queries

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ import type { LintMode } from './lang/beancount-lint';
 
  */
 export type FileOrganization = "yearly" | "monthly";
+export type DashboardDefaultPeriod = "this-month" | "last-month" | "this-year" | "last-year";
 
 export interface BeancountPluginSettings {
     /** Path to the main Beancount file. */
@@ -24,6 +25,8 @@ export interface BeancountPluginSettings {
     maxTransactionResults: number;
     /** Max entries to fetch in the journal. */
     maxJournalResults: number;
+    /** Default period shown by dashboard period summaries. */
+    dashboardDefaultPeriod: DashboardDefaultPeriod;
     // BQL Code Block Settings
     /** Whether to show tool buttons (copy, refresh) on query blocks. */
     bqlShowTools: boolean;
@@ -69,6 +72,7 @@ export const DEFAULT_SETTINGS: BeancountPluginSettings = {
     operatingCurrency: 'USD',
     maxTransactionResults: 2000,
     maxJournalResults: 1000,
+    dashboardDefaultPeriod: 'this-month',
     // BQL Code Block Settings
     bqlShowTools: true,
     bqlShowQuery: false,
@@ -226,6 +230,20 @@ export class BeancountSettingTab extends PluginSettingTab {
                     }
                 })
             );
+
+        new Setting(containerEl)
+            .setName('Default dashboard period')
+            .setDesc('Choose the period shown by dashboard summaries when the dashboard first loads.')
+            .addDropdown(dropdown => dropdown
+                .addOption('this-month', 'This Month')
+                .addOption('last-month', 'Last Month')
+                .addOption('this-year', 'This Year')
+                .addOption('last-year', 'Last Year')
+                .setValue(this.plugin.settings.dashboardDefaultPeriod || 'this-month')
+                .onChange(async (value) => {
+                    this.plugin.settings.dashboardDefaultPeriod = value as DashboardDefaultPeriod;
+                    await this.plugin.saveSettings();
+                }));
 
         new Setting(containerEl)
             .setName('Debug mode')

--- a/src/ui/partials/dashboard/OverviewTab.svelte
+++ b/src/ui/partials/dashboard/OverviewTab.svelte
@@ -5,7 +5,7 @@
 	import ErrorBanner from '../../common/ErrorBanner.svelte';
 	import type { OverviewController } from '../../../controllers/OverviewController';
 	import { writable, type Writable } from 'svelte/store'; // Import writable
-	import type { OverviewState } from '../../../controllers/OverviewController'; // Import the State type
+	import type { OverviewPeriodPreset, OverviewState } from '../../../controllers/OverviewController'; // Import the State type
 	import { AddBudgetModal } from '../../modals/AddBudgetModal';
 	import { AddTargetModal } from '../../modals/AddTargetModal';
 
@@ -20,10 +20,16 @@
 		isLoading: true,
 		error: null,
 		netWorth: '0.00 USD',
-		monthlyIncome: '0.00 USD',
-		monthlyExpenses: '0.00 USD',
-		savingsRate: '0%',
 		currency: 'USD',
+		periodPreset: 'this-month',
+		periodMode: 'month',
+		periodYear: new Date().getFullYear(),
+		periodMonth: new Date().getMonth() + 1,
+		periodLabel: '',
+		periodIncome: '0.00 USD',
+		periodExpenses: '0.00 USD',
+		periodNetIncome: '0.00 USD',
+		periodSavingsRate: '0%',
 	});
 
 	// 2. Use a reactive statement ($:) to update the local store variable
@@ -50,12 +56,89 @@
 		if (!plugin) return;
 		new AddTargetModal(plugin.app, plugin).open();
 	}
+
+	function handlePeriodPresetChange(event: Event) {
+		const preset = (event.currentTarget as HTMLSelectElement).value as OverviewPeriodPreset;
+		controller?.setPeriodPreset(preset);
+	}
+
+	function handleYearChange(event: Event) {
+		const year = Number((event.currentTarget as HTMLInputElement).value);
+		controller?.setPeriodYear(year);
+	}
+
+	function handleMonthChange(event: Event) {
+		const month = Number((event.currentTarget as HTMLSelectElement).value);
+		controller?.setPeriodMonth(month);
+	}
+
+	const months = [
+		{ value: 1, label: 'January' },
+		{ value: 2, label: 'February' },
+		{ value: 3, label: 'March' },
+		{ value: 4, label: 'April' },
+		{ value: 5, label: 'May' },
+		{ value: 6, label: 'June' },
+		{ value: 7, label: 'July' },
+		{ value: 8, label: 'August' },
+		{ value: 9, label: 'September' },
+		{ value: 10, label: 'October' },
+		{ value: 11, label: 'November' },
+		{ value: 12, label: 'December' },
+	];
+
+	const periodPresets = [
+		{ value: 'this-month', label: 'This Month' },
+		{ value: 'last-month', label: 'Last Month' },
+		{ value: 'this-year', label: 'This Year' },
+		{ value: 'last-year', label: 'Last Year' },
+		{ value: 'custom-month', label: 'Custom Month' },
+		{ value: 'custom-year', label: 'Custom Year' },
+	];
 	// -----------------------
 </script>
 <div class="beancount-overview">
 	<div class="overview-header">
-		<h3>Financial Overview</h3>
-		<button class="btn btn-primary" on:click={handleRefresh} disabled={state.isLoading}>Refresh</button>
+		<div class="overview-title">
+			<h3>Financial Overview</h3>
+			<p>{state.periodLabel}</p>
+		</div>
+		<div class="overview-actions">
+			<div class="period-controls">
+				<label>
+					<span>Period</span>
+					<select value={state.periodPreset} on:change={handlePeriodPresetChange} disabled={state.isLoading}>
+						{#each periodPresets as preset}
+							<option value={preset.value}>{preset.label}</option>
+						{/each}
+					</select>
+				</label>
+				{#if state.periodPreset === 'custom-month' || state.periodPreset === 'custom-year'}
+					<label>
+						<span>Year</span>
+						<input
+							type="number"
+							min="1"
+							step="1"
+							value={state.periodYear}
+							on:change={handleYearChange}
+							disabled={state.isLoading}
+						/>
+					</label>
+				{/if}
+				{#if state.periodPreset === 'custom-month'}
+					<label>
+						<span>Month</span>
+						<select value={state.periodMonth} on:change={handleMonthChange} disabled={state.isLoading}>
+							{#each months as month}
+								<option value={month.value}>{month.label}</option>
+							{/each}
+						</select>
+					</label>
+				{/if}
+			</div>
+			<button class="btn btn-primary" on:click={handleRefresh} disabled={state.isLoading}>Refresh</button>
+		</div>
 	</div>
 
 	{#if state.isLoading}
@@ -74,9 +157,9 @@
 		
 		<div class="kpi-grid">
 			<CardComponent label="Total Balance" value={state.netWorth} comparison="Assets minus liabilities" />
-			<CardComponent label="Monthly Income" value={state.monthlyIncome} comparison="Current month earnings" />
-			<CardComponent label="Monthly Expenses" value={state.monthlyExpenses} comparison="Current month spending" />
-			<CardComponent label="Savings Rate" value={state.savingsRate} comparison="Income minus expenses" />
+			<CardComponent label="Income" value={state.periodIncome} comparison={state.periodLabel} />
+			<CardComponent label="Expenses" value={state.periodExpenses} comparison={state.periodLabel} />
+			<CardComponent label="Savings Rate" value={state.periodSavingsRate} comparison={`Net income: ${state.periodNetIncome}`} />
 		</div>
 
 		<IndicatorsSection
@@ -94,7 +177,8 @@
 	.overview-header {
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
+		align-items: flex-end;
+		gap: var(--size-4-4);
 		margin-bottom: var(--size-4-4);
 		padding-bottom: var(--size-4-2);
 		border-bottom: 1px solid var(--background-modifier-border);
@@ -104,6 +188,20 @@
 		margin: 0;
 		color: var(--text-normal);
 		font-size: var(--font-ui-larger);
+	}
+
+	.overview-title p {
+		margin: var(--size-4-1) 0 0;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+	}
+
+	.overview-actions {
+		display: flex;
+		align-items: flex-end;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		gap: var(--size-4-2);
 	}
 	
 	.btn {
@@ -135,6 +233,37 @@
 		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 		gap: var(--size-4-4);
 	}
+
+	.period-controls {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		gap: var(--size-4-2);
+	}
+
+	.period-controls label {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		color: var(--text-muted);
+		font-size: var(--font-ui-smaller);
+	}
+
+	.period-controls select,
+	.period-controls input {
+		min-width: 110px;
+		height: 32px;
+		padding: 0 8px;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 4px;
+		background: var(--background-primary);
+		color: var(--text-normal);
+		font-size: var(--font-ui-small);
+	}
+
+	.period-controls input {
+		width: 110px;
+	}
 	
 	.conversion-warning {
 		display: flex;
@@ -155,4 +284,19 @@
 	}
 	
 	.error-message { color: var(--text-error); }
+
+	@media (max-width: 700px) {
+		.overview-header {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.overview-actions {
+			justify-content: flex-start;
+		}
+
+		.period-controls {
+			justify-content: flex-start;
+		}
+	}
 </style>


### PR DESCRIPTION
## Background

The Overview dashboard currently shows income, expenses, and savings rate for the current month only.

That works well for users who update their ledger continuously, but it is less convenient for users who reconcile finances monthly or want to review a previous month/year. In those cases, users need a quick way to switch the Overview KPIs to another reporting period without writing a custom BQL query or creating a separate report page.

## Summary

This PR adds a period selector to the Overview dashboard and applies the selected period to the KPI cards.

Supported periods:

- This Month
- Last Month
- This Year
- Last Year
- Custom Month
- Custom Year

The default remains `This Month`, so the existing Overview behavior is preserved for the default view.

## Implementation Notes

- Adds period-based income, expense, and net income queries.
- Applies the selected period end date to the total balance query, so `Total Balance` reflects the period-end net worth instead of always showing current net worth.
- Updates the existing Overview KPI cards instead of adding a separate reports page.
- Shows net income in the savings rate card subtitle for additional context.
- Keeps the existing total asset/liability/net worth query helpers backward compatible when no date is passed, so current-balance consumers such as the sidebar continue to work.

## Verification

- Ran `npm run build`.
- Tested the generated BQL queries against a real Beancount ledger.
- Verified May 2026 period-end net worth returns `4,329,025.32 CNY` using `date < 2026-06-01` and valuation date `2026-06-01`, matching the Reports assets view for the same period.
- Verified the plugin builds and deploys locally in Obsidian, and the Overview period selector updates income, expenses, savings rate, and total balance consistently.

No screenshot is included because the current test ledger contains personal financial data.
