### PR TITLE
Improve date input picker behavior

### DIFF
--- a/src/ui/actions/nativeDatePicker.ts
+++ b/src/ui/actions/nativeDatePicker.ts
@@ -1,0 +1,33 @@
+type DatePickerInput = HTMLInputElement & {
+	showPicker?: () => void;
+};
+
+export function nativeDatePicker(node: DatePickerInput) {
+	const openPicker = () => {
+		if (node.disabled || node.readOnly || typeof node.showPicker !== 'function') {
+			return;
+		}
+
+		try {
+			node.showPicker();
+		} catch {
+			// Some environments only allow this from direct user gestures.
+		}
+	};
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			openPicker();
+		}
+	};
+
+	node.addEventListener('click', openPicker);
+	node.addEventListener('keydown', handleKeydown);
+
+	return {
+		destroy() {
+			node.removeEventListener('click', openPicker);
+			node.removeEventListener('keydown', handleKeydown);
+		},
+	};
+}

--- a/src/ui/modals/AddBudgetModal.svelte
+++ b/src/ui/modals/AddBudgetModal.svelte
@@ -1,6 +1,7 @@
 <!-- src/ui/modals/AddBudgetModal.svelte -->
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
+	import { nativeDatePicker } from '../actions/nativeDatePicker';
 
 	const dispatch = createEventDispatcher();
 
@@ -180,7 +181,7 @@
 		{#if isRollover}
 			<div class="form-group full-width">
 				<label for="budget-start">Start Date</label>
-				<input id="budget-start" type="date" bind:value={startDate} />
+				<input id="budget-start" type="date" bind:value={startDate} use:nativeDatePicker />
 			</div>
 		{/if}
 

--- a/src/ui/modals/AddTargetModal.svelte
+++ b/src/ui/modals/AddTargetModal.svelte
@@ -1,6 +1,7 @@
 <!-- src/ui/modals/AddTargetModal.svelte -->
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
+	import { nativeDatePicker } from '../actions/nativeDatePicker';
 
 	const dispatch = createEventDispatcher();
 
@@ -180,7 +181,7 @@
 		{#if isRollover}
 			<div class="form-group full-width">
 				<label for="target-start">Start Date</label>
-				<input id="target-start" type="date" bind:value={startDate} />
+				<input id="target-start" type="date" bind:value={startDate} use:nativeDatePicker />
 			</div>
 		{/if}
 

--- a/src/ui/modals/CommodityCreateModal.svelte
+++ b/src/ui/modals/CommodityCreateModal.svelte
@@ -1,6 +1,7 @@
 <!-- src/ui/modals/CommodityCreateModal.svelte -->
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
+    import { nativeDatePicker } from '../actions/nativeDatePicker';
 
     const dispatch = createEventDispatcher();
 
@@ -135,6 +136,7 @@
                 id="date"
                 type="date"
                 bind:value={date}
+                use:nativeDatePicker
                 required
             />
             <div class="hint">Date when the commodity was first introduced</div>

--- a/src/ui/modals/TransactionEditModal.svelte
+++ b/src/ui/modals/TransactionEditModal.svelte
@@ -9,6 +9,7 @@
 	} from "../../models/journal";
 	import { runQuery } from "../../utils/queryRunner";
 	import { getQueryDirectives } from "../../utils";
+	import { nativeDatePicker } from "../actions/nativeDatePicker";
 
 	export let transaction: JournalTransaction | null = null; // Now optional for Add mode
 	export let entry: JournalEntry | null = null; // Support for any entry type
@@ -813,7 +814,7 @@
 			<div class="transaction-header-row">
 				<div class="form-group header-date">
 					<label for="date">Date *</label>
-					<input type="date" id="date" bind:value={date} required />
+					<input type="date" id="date" bind:value={date} required use:nativeDatePicker />
 				</div>
 
 				<div class="form-group header-flag">
@@ -1041,6 +1042,7 @@
 										type="date"
 										bind:value={posting.cost.date}
 										max={date}
+										use:nativeDatePicker
 									/>
 								</div>
 
@@ -1268,6 +1270,7 @@
 						type="date"
 						id="balance-date"
 						bind:value={date}
+						use:nativeDatePicker
 						required
 					/>
 				</div>
@@ -1320,6 +1323,7 @@
 						type="date"
 						id="note-date"
 						bind:value={date}
+						use:nativeDatePicker
 						required
 					/>
 				</div>
@@ -1358,6 +1362,7 @@
 						type="date"
 						id="query-date"
 						bind:value={date}
+						use:nativeDatePicker
 						required
 					/>
 				</div>

--- a/src/ui/partials/dashboard/JournalTab.svelte
+++ b/src/ui/partials/dashboard/JournalTab.svelte
@@ -12,6 +12,7 @@
     import { Notice } from 'obsidian';
     import type { JournalEntry } from '../../../models/journal';
     import { Logger } from '../../../utils/logger';
+    import { nativeDatePicker } from '../../actions/nativeDatePicker';
 
     // Instead of importing Controller, we receive the Store
     export let store: any;
@@ -280,11 +281,11 @@
         <div class="filter-row">
              <div class="filter-group">
                 <label for="start">From</label>
-                <input type="date" id="start" bind:value={startDate} on:change={applyFilters} disabled={isLoading} />
+                <input type="date" id="start" bind:value={startDate} on:change={applyFilters} disabled={isLoading} use:nativeDatePicker />
             </div>
              <div class="filter-group">
                 <label for="end">To</label>
-                <input type="date" id="end" bind:value={endDate} on:change={applyFilters} disabled={isLoading} />
+                <input type="date" id="end" bind:value={endDate} on:change={applyFilters} disabled={isLoading} use:nativeDatePicker />
             </div>
             <div class="filter-group">
                 <label for="payee">Payee</label>

--- a/src/ui/partials/dashboard/TransactionsTab.svelte
+++ b/src/ui/partials/dashboard/TransactionsTab.svelte
@@ -6,6 +6,7 @@
 	import SkeletonLoader from '../../common/SkeletonLoader.svelte';
 	import ErrorBanner from '../../common/ErrorBanner.svelte';
 	import EmptyState from '../../common/EmptyState.svelte';
+	import { nativeDatePicker } from '../../actions/nativeDatePicker';
 
 	// --- PROPS ---
 	// Receive the controller
@@ -129,9 +130,9 @@
 			</div>
 			<div class="date-range">
 				<label for="start-date">From:</label>
-				<input type="date" id="start-date" bind:value={startDate} disabled={state.isLoading} />
+				<input type="date" id="start-date" bind:value={startDate} disabled={state.isLoading} use:nativeDatePicker />
 				<label for="end-date">To:</label>
-				<input type="date" id="end-date" bind:value={endDate} disabled={state.isLoading} />
+				<input type="date" id="end-date" bind:value={endDate} disabled={state.isLoading} use:nativeDatePicker />
 			</div>
 			<div>
 				<label for="payee-filter">Payee:</label>


### PR DESCRIPTION
## Problem

Date fields currently rely on the browser/Electron default `<input type="date">` interaction. In Obsidian, users can see the date input UI but clicking the field may still feel like manual entry only, especially in dashboard filters such as Journal `From` / `To`.

This makes date filtering and date entry less discoverable than expected for a finance dashboard.

## Solution

- Add a small reusable Svelte action, `nativeDatePicker`, for native date inputs.
- When a date input is clicked, the action calls `HTMLInputElement.showPicker()` when the runtime supports it.
- Keep the existing `<input type="date">` fields intact, so manual typing, validation, browser-native behavior, and unsupported-runtime fallback all remain unchanged.
- Apply the action to existing date fields in:
  - Journal filters
  - Transactions filters
  - Add/edit transaction modal date fields
  - Balance, note, and query date fields
  - Commodity creation date
  - Budget and target rollover start dates

## Screenshot

![Native date picker opened from the Journal date filter](https://raw.githubusercontent.com/banpie/obsidian-finance-plugin/codex/pr-assets/pr-235/date-picker-open.png)

## Notes

This intentionally avoids adding a date-picker dependency. The plugin already uses native date inputs, so this change only makes the native picker easier to invoke in Obsidian/Electron.

If `showPicker()` is unavailable or rejected by the runtime, the action catches the error and the input continues to behave exactly as before.

## Verification

- `npm run build`
- `git diff --check`
- Local Obsidian deployment via the existing local deploy workflow, with the built `main.js` confirmed to contain the `showPicker` logic.

## Known validation issue

- `npm run eslint` currently fails before linting source files due to an existing `eslint-plugin-obsidianmd` config loading error:
  - `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined`
