### PR TITLE
Improve commodity metadata display and price history

### DIFF
--- a/src/controllers/CommoditiesController.ts
+++ b/src/controllers/CommoditiesController.ts
@@ -8,6 +8,7 @@ import {
     parseCommoditiesPriceDataCSV,
     parseCommodityDetailsCSV,
     parseCombinedCommodityDataCSV,
+    parseCommodityPriceHistoryCSV,
     validatePriceSource,
     validateLogoUrl,
     saveCommodityMetadata
@@ -23,6 +24,8 @@ export interface CommodityInfo {
     symbol: string;
     /** Alias for symbol (for compatibility with services). */
     name?: string;
+    /** Human-readable display name from commodity metadata. */
+    displayName?: string | null;
     /** Whether explicit price metadata exists for this commodity. */
     hasPriceMetadata: boolean;
     /** The price metadata string (e.g. "yahoo/AAPL") if exists. */
@@ -53,6 +56,18 @@ export interface CommodityInfo {
     filename?: string;
     /** The line number in the file where this commodity is defined. */
     lineno?: number;
+    /** Price directive history for this commodity. */
+    priceHistory?: CommodityPricePoint[];
+}
+
+/**
+ * A single dated price directive for a commodity.
+ */
+export interface CommodityPricePoint {
+    date: string;
+    amount: number;
+    currency: string;
+    amountRaw: string;
 }
 
 /**
@@ -153,8 +168,10 @@ export class CommoditiesController {
             return;
         }
 
+        const normalizedSearch = searchTerm.toLowerCase();
         const filtered = commodities.filter(commodity =>
-            commodity.symbol.toLowerCase().includes(searchTerm.toLowerCase())
+            commodity.symbol.toLowerCase().includes(normalizedSearch) ||
+            (commodity.displayName || '').toLowerCase().includes(normalizedSearch)
         );
         this.filteredCommodities.set(filtered);
     }
@@ -204,15 +221,20 @@ export class CommoditiesController {
                 // Prefer combined query values; fall back to priceDataMap for price/logo
                 const logoUrl = combined?.logo || priceData?.logo || null;
                 const price = combined?.price ?? priceData?.price ?? null;
+                const displayName = combined?.displayName || priceData?.displayName || null;
 
                 return {
                     symbol,
+                    name: symbol,
+                    displayName,
                     hasPriceMetadata: !!(logoUrl || price),
                     priceMetadata: logoUrl || undefined,
                     fullMetadata: {
+                        ...(displayName ? { name: displayName } : {}),
                         ...(logoUrl ? { logo: logoUrl } : {}),
                     },
                     metadata: {
+                        ...(displayName ? { name: displayName } : {}),
                         ...(logoUrl ? { logo: logoUrl } : {}),
                     },
                     currentPrice: price ? `${price} ${operatingCurrency}` : undefined,
@@ -259,20 +281,38 @@ export class CommoditiesController {
     public async loadCommodityDetails(symbol: string): Promise<void> {
         Logger.log('[CommoditiesController] loadCommodityDetails:', symbol);
         try {
-            const detailsCSV = await this.plugin.runQuery(queries.getCommodityDetailsQuery(symbol));
+            const [detailsCSV, priceHistoryCSV] = await Promise.all([
+                this.plugin.runQuery(queries.getCommodityDetailsQuery(symbol)),
+                this.plugin.runQuery(queries.getCommodityPriceHistoryQuery(symbol))
+            ]);
             const details = parseCommodityDetailsCSV(detailsCSV);
+            const priceHistory = parseCommodityPriceHistoryCSV(priceHistoryCSV);
 
             Logger.log('[CommoditiesController] loadCommodityDetails: parsed ->', details);
 
+            const existing = get(this.selectedCommodity) || this.getCommodityBySymbol(symbol);
+            const metadata = {
+                ...(existing?.metadata || {}),
+                ...details.metadata,
+                ...(details.displayName ? { name: details.displayName } : {}),
+                ...(details.logo ? { logo: details.logo } : {}),
+                ...(details.priceMetadata ? { price: details.priceMetadata } : {}),
+            };
+
             this.selectedCommodity.set({
+                ...(existing || {}),
                 symbol: details.symbol || symbol,
-                hasPriceMetadata: !!details.priceMetadata,
+                name: details.symbol || symbol,
+                displayName: details.displayName || existing?.displayName || null,
+                hasPriceMetadata: !!details.priceMetadata || !!existing?.hasPriceMetadata,
                 priceMetadata: details.priceMetadata || undefined,
-                fullMetadata: details.metadata,
-                metadata: details.metadata,
-                currentPrice: undefined,  // Detail query doesn't include current price
+                pricemetadata: details.priceMetadata || undefined,
+                fullMetadata: metadata,
+                metadata,
+                logoUrl: details.logo || existing?.logoUrl || null,
                 filename: details.filename || undefined,
-                lineno: details.lineno || undefined
+                lineno: details.lineno || undefined,
+                priceHistory
             });
 
         } catch (error) {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -218,12 +218,17 @@ export function getIndicatorBalanceQuery(currency: string, accountString: string
 
 // --- Commodities Queries ---
 
+function escapeBqlString(value: string): string {
+	return value.replace(/'/g, "''");
+}
+
 export function getAllCommoditiesQuery(): string {
 	return `SELECT name AS name_ FROM #commodities GROUP BY name`;
 }
 
 export function getCommoditiesPriceDataQuery(currency: string): string {
-	return `SELECT last(date) AS date_, last(currency) AS currency_, round(getprice(last(currency), '${currency}'),2) AS price_, currency_meta(last(currency), 'logo') AS logo_, bool(today()-1<last(date)) AS islatest_ FROM #prices GROUP BY currency`;
+	const safeCurrency = escapeBqlString(currency);
+	return `SELECT last(date) AS date_, last(currency) AS currency_, currency_meta(last(currency), 'name') AS displayname_, round(getprice(last(currency), '${safeCurrency}'),2) AS price_, currency_meta(last(currency), 'logo') AS logo_, bool(today()-1<last(date)) AS islatest_ FROM #prices GROUP BY currency`;
 }
 
 
@@ -232,18 +237,26 @@ export function getCommoditiesPriceDataQuery(currency: string): string {
  * Combined holdings query: all data needed to populate the commodity tab in one pass.
  * For each currency held in Asset accounts, returns:
  *   - currency_  : commodity symbol (e.g. "DOGE")
+ *   - displayname_: human-readable display name from commodity metadata
  *   - units_     : raw inventory string (e.g. "65.64 DOGE")
  *   - valueOp_   : holdings converted to operating currency (e.g. "658.37 INR")
  *   - price_     : latest price in operating currency (e.g. 10.03)
  *   - logo_      : logo URL from commodity metadata
  */
 export function getCombinedCommodityDataQuery(operatingCurrency: string): string {
-	return `SELECT currency AS currency_, units(sum(position)) AS units_, convert(sum(position), '${operatingCurrency}') AS valueOp_, round(getprice(last(currency), '${operatingCurrency}'), 2) AS price_, currency_meta(last(currency), 'logo') AS logo_ WHERE account ~ '^Assets' GROUP BY currency`;
+	const safeOperatingCurrency = escapeBqlString(operatingCurrency);
+	return `SELECT currency AS currency_, currency_meta(last(currency), 'name') AS displayname_, units(sum(position)) AS units_, convert(sum(position), '${safeOperatingCurrency}') AS valueOp_, round(getprice(last(currency), '${safeOperatingCurrency}'), 2) AS price_, currency_meta(last(currency), 'logo') AS logo_ WHERE account ~ '^Assets' GROUP BY currency`;
 }
 
 
 export function getCommodityDetailsQuery(symbol: string): string {
-	return `SELECT name AS name_, last(meta) AS meta_, currency_meta(last(name),'logo') AS logo_, currency_meta(last(name), 'price') AS pricemetadata_, meta('filename') AS filename_, meta('lineno') AS lineno_ FROM #commodities WHERE name='${symbol}'`;
+	const safeSymbol = escapeBqlString(symbol);
+	return `SELECT name AS name_, currency_meta(last(name), 'name') AS displayname_, last(meta) AS meta_, currency_meta(last(name),'logo') AS logo_, currency_meta(last(name), 'price') AS pricemetadata_, meta('filename') AS filename_, meta('lineno') AS lineno_ FROM #commodities WHERE name='${safeSymbol}'`;
+}
+
+export function getCommodityPriceHistoryQuery(symbol: string): string {
+	const safeSymbol = escapeBqlString(symbol);
+	return `SELECT date AS date_, amount AS amount_ FROM #prices WHERE currency='${safeSymbol}' ORDER BY date`;
 }
 
 // --- Price Queries ---

--- a/src/ui/modals/CommodityDetailModal.svelte
+++ b/src/ui/modals/CommodityDetailModal.svelte
@@ -565,9 +565,11 @@
 
 	/* ── Key-value rows ───────────────────────────────── */
 	.kv-row {
-		display: flex;
-		align-items: center;
-		gap: 12px;
+		display: grid;
+		grid-template-columns: minmax(150px, 0.28fr) minmax(0, 1fr) auto;
+		align-items: start;
+		column-gap: 14px;
+		row-gap: 8px;
 		padding: 9px 14px;
 		border-bottom: 1px solid var(--background-modifier-border);
 		font-size: 13px;
@@ -578,24 +580,38 @@
 	}
 
 	.kv-key {
-		width: 100px;
-		flex-shrink: 0;
 		color: var(--text-muted);
 		font-size: 12px;
+		line-height: 1.45;
+		overflow-wrap: anywhere;
 	}
 
 	.kv-value {
-		flex: 1;
+		min-width: 0;
 		color: var(--text-normal);
-		word-break: break-all;
+		overflow-wrap: anywhere;
+		word-break: normal;
+		white-space: pre-wrap;
 		font-family: var(--font-monospace);
 		font-size: 12px;
+		line-height: 1.45;
 	}
 
 	.kv-actions {
 		display: flex;
 		gap: 6px;
-		flex-shrink: 0;
+		justify-content: flex-end;
+	}
+
+	@media (max-width: 520px) {
+		.kv-row {
+			grid-template-columns: 1fr;
+		}
+
+		.kv-actions {
+			justify-content: flex-start;
+			flex-wrap: wrap;
+		}
 	}
 
 	/* ── Inline edit ──────────────────────────────────── */

--- a/src/ui/modals/CommodityDetailModal.svelte
+++ b/src/ui/modals/CommodityDetailModal.svelte
@@ -86,12 +86,21 @@
 		return sym ? sym.slice(0, 2).toUpperCase() : "??";
 	}
 
+	function formatPriceAmount(value: number | string | null | undefined) {
+		if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+		return value.toLocaleString(undefined, {
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 4,
+		});
+	}
+
 	function buildPriceHistoryChart(
 		history: Array<{ date: string; amount: number; currency: string }>,
 	): ChartConfiguration | null {
 		if (!history.length) return null;
 
-		const latestCurrency = history[history.length - 1]?.currency || "";
+		const currencies = Array.from(new Set(history.map((point) => point.currency).filter(Boolean)));
+		const labelCurrency = currencies.length === 1 ? currencies[0] : "mixed";
 
 		return {
 			type: "line",
@@ -99,7 +108,7 @@
 				labels: history.map((point) => point.date),
 				datasets: [
 					{
-						label: latestCurrency ? `Price (${latestCurrency})` : "Price",
+						label: labelCurrency ? `Price (${labelCurrency})` : "Price",
 						data: history.map((point) => point.amount),
 						borderColor: "rgb(75, 192, 192)",
 						backgroundColor: "rgba(75, 192, 192, 0.12)",
@@ -121,7 +130,8 @@
 						callbacks: {
 							label: (context) => {
 								const value = context.parsed.y;
-								return `Price: ${typeof value === "number" ? value.toLocaleString() : value} ${latestCurrency}`;
+								const currency = history[context.dataIndex]?.currency || "";
+								return `Price: ${formatPriceAmount(value)} ${currency}`.trim();
 							},
 						},
 					},
@@ -136,7 +146,7 @@
 						display: true,
 						ticks: {
 							callback: (value) =>
-								typeof value === "number" ? value.toLocaleString() : value,
+								typeof value === "number" ? formatPriceAmount(value) : value,
 						},
 					},
 				},
@@ -215,7 +225,7 @@
 							{#each priceHistory.slice().reverse() as point}
 								<tr>
 									<td>{point.date}</td>
-									<td>{point.amount.toLocaleString()}</td>
+									<td>{formatPriceAmount(point.amount)}</td>
 									<td>{point.currency}</td>
 								</tr>
 							{/each}

--- a/src/ui/modals/CommodityDetailModal.svelte
+++ b/src/ui/modals/CommodityDetailModal.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount, tick } from "svelte";
+	import type { ChartConfiguration } from "chart.js/auto";
+	import ChartComponent from "../common/ChartComponent.svelte";
 	export let symbol: string;
 	export let commodity: any = {
 		symbol: "",
@@ -15,6 +17,7 @@
 	let editingPrice = false;
 	let logoInput = "";
 	let priceInput = "";
+	let priceHistoryView: "chart" | "table" = "chart";
 
 	let priceInputRef: HTMLInputElement | null = null;
 	let logoInputRef: HTMLInputElement | null = null;
@@ -71,13 +74,75 @@
 	$: logoUrl = commodity?.metadata?.logo || commodity?.logo_url;
 	$: priceSource = commodity?.metadata?.price || commodity?.price_meta;
 	$: currentPrice = commodity?.currentPrice;
+	$: displayName = commodity?.displayName || commodity?.metadata?.name || "";
+	$: priceHistory = commodity?.priceHistory || [];
+	$: priceHistoryChartConfig = buildPriceHistoryChart(priceHistory);
 	$: otherMeta = Object.entries(commodity?.metadata || {}).filter(
-		([k]) => k !== "logo" && k !== "price",
+		([k]) => k !== "logo" && k !== "price" && k !== "name",
 	);
 
 	// Generate initials + color for fallback avatar
 	function getInitials(sym: string) {
 		return sym ? sym.slice(0, 2).toUpperCase() : "??";
+	}
+
+	function buildPriceHistoryChart(
+		history: Array<{ date: string; amount: number; currency: string }>,
+	): ChartConfiguration | null {
+		if (!history.length) return null;
+
+		const latestCurrency = history[history.length - 1]?.currency || "";
+
+		return {
+			type: "line",
+			data: {
+				labels: history.map((point) => point.date),
+				datasets: [
+					{
+						label: latestCurrency ? `Price (${latestCurrency})` : "Price",
+						data: history.map((point) => point.amount),
+						borderColor: "rgb(75, 192, 192)",
+						backgroundColor: "rgba(75, 192, 192, 0.12)",
+						tension: 0.25,
+						fill: true,
+						pointRadius: history.length > 60 ? 0 : 3,
+						pointHoverRadius: 5,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: {
+					legend: { display: true, position: "top" },
+					tooltip: {
+						mode: "index",
+						intersect: false,
+						callbacks: {
+							label: (context) => {
+								const value = context.parsed.y;
+								return `Price: ${typeof value === "number" ? value.toLocaleString() : value} ${latestCurrency}`;
+							},
+						},
+					},
+				},
+				scales: {
+					x: {
+						display: true,
+						ticks: { maxTicksLimit: 8 },
+						grid: { display: false },
+					},
+					y: {
+						display: true,
+						ticks: {
+							callback: (value) =>
+								typeof value === "number" ? value.toLocaleString() : value,
+						},
+					},
+				},
+				interaction: { mode: "nearest", axis: "x", intersect: false },
+			},
+		};
 	}
 </script>
 
@@ -99,9 +164,63 @@
 		</div>
 		<div class="identity-info">
 			<div class="symbol-name">{symbol}</div>
+			{#if displayName}
+				<div class="display-name">{displayName}</div>
+			{/if}
 			{#if currentPrice}
 				<div class="current-price">
 					Current price: <strong>{currentPrice}</strong>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Price History -->
+	<div class="section">
+		<div class="section-heading">
+			<p class="section-title">Price History</p>
+			{#if priceHistory.length > 0}
+				<div class="segmented-control" role="group" aria-label="Price history view">
+					<button
+						type="button"
+						class:active={priceHistoryView === "chart"}
+						on:click={() => (priceHistoryView = "chart")}
+					>Chart</button>
+					<button
+						type="button"
+						class:active={priceHistoryView === "table"}
+						on:click={() => (priceHistoryView = "table")}
+					>Table</button>
+				</div>
+			{/if}
+		</div>
+		<div class="section-card history-card">
+			{#if priceHistory.length === 0}
+				<div class="empty-history">No price directives found for this commodity.</div>
+			{:else if priceHistoryView === "chart" && priceHistoryChartConfig}
+				<div class="price-history-chart">
+					<ChartComponent config={priceHistoryChartConfig} height="240px" />
+				</div>
+			{:else}
+				<div class="price-history-table-wrap">
+					<table class="price-history-table">
+						<thead>
+							<tr>
+								<th>Date</th>
+								<th>Price</th>
+								<th>Currency</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each priceHistory.slice().reverse() as point}
+								<tr>
+									<td>{point.date}</td>
+									<td>{point.amount.toLocaleString()}</td>
+									<td>{point.currency}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
 				</div>
 			{/if}
 		</div>
@@ -323,11 +442,25 @@
 		font-size: 16px;
 	}
 
+	.display-name {
+		margin-top: 4px;
+		color: var(--text-muted);
+		font-size: 14px;
+		line-height: 1.35;
+	}
+
 	/* ── Section ──────────────────────────────────────── */
 	.section {
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
+	}
+
+	.section-heading {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
 	}
 
 	.section-title {
@@ -344,6 +477,80 @@
 		border: 1px solid var(--background-modifier-border);
 		border-radius: 8px;
 		overflow: hidden;
+	}
+
+	.history-card {
+		min-height: 72px;
+	}
+
+	.segmented-control {
+		display: inline-flex;
+		align-items: center;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 6px;
+		overflow: hidden;
+		background: var(--background-secondary);
+	}
+
+	.segmented-control button {
+		border: 0;
+		border-right: 1px solid var(--background-modifier-border);
+		background: transparent;
+		color: var(--text-muted);
+		padding: 4px 10px;
+		font-size: 12px;
+		cursor: pointer;
+	}
+
+	.segmented-control button:last-child {
+		border-right: 0;
+	}
+
+	.segmented-control button.active {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent);
+	}
+
+	.price-history-chart {
+		height: 240px;
+		padding: 12px;
+	}
+
+	.price-history-table-wrap {
+		max-height: 280px;
+		overflow: auto;
+	}
+
+	.price-history-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 12px;
+	}
+
+	.price-history-table th,
+	.price-history-table td {
+		padding: 8px 12px;
+		border-bottom: 1px solid var(--background-modifier-border);
+		text-align: left;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.price-history-table th {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		background: var(--background-secondary);
+		color: var(--text-muted);
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.empty-history {
+		padding: 16px;
+		color: var(--text-muted);
+		font-size: 13px;
 	}
 
 	/* ── Key-value rows ───────────────────────────────── */

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -115,7 +115,7 @@
 					{/if}
 				</div>
 				<div class="name-box">
-					<span class="symbol-text"
+					<span class="symbol-text" title={commodity?.symbol || `UNKNOWN_${index}`}
 						>{commodity?.symbol || `UNKNOWN_${index}`}</span
 					>
 				</div>
@@ -140,13 +140,13 @@
 		<div class="card-body">
 			<!-- Value (primary) -->
 			{#if (commodity?.valueInOperatingCurrency ?? 0) > 0}
-				<div class="value-container">
+				<div class="value-container" title={`${(commodity.valueInOperatingCurrency ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${operatingCurrency}`}>
 					<span class="value-main">{formatValue(commodity.valueInOperatingCurrency ?? 0)}</span>
 					<span class="value-currency">{operatingCurrency}</span>
 				</div>
 			{:else if commodity?.holdingsRaw && !commodity?.isOperatingCurrency}
 				<!-- Has holdings but no price to convert — show raw units -->
-				<div class="value-container">
+				<div class="value-container" title={commodity.holdingsRaw}>
 					<span class="value-main no-price">{commodity.holdingsRaw.split(' ')[0]}</span>
 					<span class="value-currency">{commodity.symbol}</span>
 				</div>
@@ -158,7 +158,7 @@
 			{/if}
 
 			{#if displayName}
-				<div class="card-display-name">{displayName}</div>
+				<div class="card-display-name" title={displayName}>{displayName}</div>
 			{/if}
 
 			{#if commodity?.isOperatingCurrency}
@@ -172,7 +172,7 @@
 				<div class="data-row">
 					<span class="data-label">Price</span>
 					{#if commodity?.currentPrice}
-						<span class="data-value">{commodity.currentPrice}</span>
+						<span class="data-value" title={commodity.currentPrice}>{commodity.currentPrice}</span>
 					{:else}
 						<span class="data-value unavailable">No price available</span>
 					{/if}
@@ -182,7 +182,7 @@
 				<div class="data-row">
 					<span class="data-label">Holdings</span>
 					{#if commodity?.holdingsRaw}
-						<span class="data-value">{commodity.holdingsRaw}</span>
+						<span class="data-value" title={commodity.holdingsRaw}>{commodity.holdingsRaw}</span>
 					{:else}
 						<span class="data-value unavailable">0 {commodity?.symbol}</span>
 					{/if}
@@ -248,6 +248,8 @@
 		height: 100%;
 		display: flex;
 		flex-direction: column;
+		align-items: stretch;
+		justify-content: flex-start;
 		padding: var(--size-4-3);
 		gap: var(--size-4-3);
 		background: transparent;
@@ -256,6 +258,9 @@
 		text-align: left;
 		color: inherit;
 		font-family: inherit;
+		appearance: none;
+		box-sizing: border-box;
+		min-width: 0;
 	}
 
 	.commodity-card:focus-visible {
@@ -268,13 +273,16 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: flex-start;
+		gap: 10px;
 		width: 100%;
+		min-width: 0;
 	}
 
 	.identity {
 		display: flex;
 		align-items: center;
 		gap: 12px;
+		flex: 1 1 auto;
 		min-width: 0;
 	}
 
@@ -324,6 +332,7 @@
 	}
 
 	.name-box {
+		flex: 1 1 auto;
 		min-width: 0;
 	}
 
@@ -355,6 +364,7 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
+		flex: 0 0 auto;
 		padding: 4px 10px;
 		border-radius: 20px;
 		font-size: 10px;
@@ -377,10 +387,15 @@
 	}
 
 	.status-dot {
+		flex: 0 0 auto;
 		width: 6px;
 		height: 6px;
 		border-radius: 50%;
 		background: currentColor;
+	}
+
+	.status-label {
+		white-space: nowrap;
 	}
 
 	.live .status-dot {
@@ -408,17 +423,25 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0;
+		min-width: 0;
 	}
 
 	/* Total value — primary display */
 	.value-container {
 		display: flex;
 		align-items: baseline;
+		justify-content: flex-start;
 		gap: 4px;
 		margin-bottom: 6px;
+		min-width: 0;
 	}
 
 	.value-main {
+		display: block;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 		font-size: 22px;
 		font-weight: 700;
 		color: var(--text-accent);
@@ -433,6 +456,7 @@
 	}
 
 	.value-currency {
+		flex: 0 0 auto;
 		font-size: 11px;
 		font-weight: 600;
 		color: var(--text-muted);
@@ -450,8 +474,8 @@
 
 	/* Price + Holdings rows */
 	.data-row {
-		display: flex;
-		justify-content: space-between;
+		display: grid;
+		grid-template-columns: 78px minmax(0, 1fr);
 		align-items: baseline;
 		gap: 10px;
 		padding: 6px 0;
@@ -488,6 +512,10 @@
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		font-weight: 600;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.data-value {
@@ -552,11 +580,6 @@
 	.commodity-card-wrapper.is-operating::after {
 		opacity: 1;
 	}
-
-	.commodity-card-wrapper.is-operating .value-container {
-		justify-content: center;
-	}
-
 	.operating-badge {
 		display: inline-block;
 		margin-left: 8px;

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -118,9 +118,6 @@
 					<span class="symbol-text"
 						>{commodity?.symbol || `UNKNOWN_${index}`}</span
 					>
-					{#if displayName}
-						<span class="display-name-text">{displayName}</span>
-					{/if}
 				</div>
 			</div>
 
@@ -158,6 +155,10 @@
 					<span class="value-main no-price">0.00</span>
 					<span class="value-currency">{operatingCurrency}</span>
 				</div>
+			{/if}
+
+			{#if displayName}
+				<div class="card-display-name">{displayName}</div>
 			{/if}
 
 			{#if commodity?.isOperatingCurrency}
@@ -338,6 +339,17 @@
 		white-space: nowrap;
 	}
 
+	.card-display-name {
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1.35;
+		margin: -1px 0 6px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
 	/* STATUS PILL */
 	.status-pill {
 		display: flex;
@@ -441,6 +453,7 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: baseline;
+		gap: 10px;
 		padding: 6px 0;
 		border-top: 1px dashed var(--background-modifier-border-hover);
 		font-size: 11px;
@@ -481,6 +494,11 @@
 		color: var(--text-normal);
 		font-weight: 600;
 		font-variant-numeric: tabular-nums;
+		min-width: 0;
+		text-align: right;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.data-value.unavailable {

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -84,13 +84,18 @@
 			return dateStr;
 		}
 	}
+
+	$: displayName = commodity?.displayName || commodity?.metadata?.name || "";
+	$: ariaLabel = displayName
+		? `View details for ${commodity?.symbol || `UNKNOWN_${index}`} (${displayName})`
+		: `View details for ${commodity?.symbol || `UNKNOWN_${index}`}`;
 </script>
 
 <div class="commodity-card-wrapper" class:is-operating={commodity?.isOperatingCurrency}>
 	<button
 		class="commodity-card"
 		on:click={handleClick}
-		aria-label="View details for {commodity?.symbol || `UNKNOWN_${index}`}"
+		aria-label={ariaLabel}
 		type="button"
 	>
 		<div class="card-header">
@@ -113,6 +118,9 @@
 					<span class="symbol-text"
 						>{commodity?.symbol || `UNKNOWN_${index}`}</span
 					>
+					{#if displayName}
+						<span class="display-name-text">{displayName}</span>
+					{/if}
 				</div>
 			</div>
 
@@ -266,6 +274,7 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
+		min-width: 0;
 	}
 
 	.logo-box {
@@ -303,10 +312,30 @@
 	}
 
 	.symbol-text {
+		display: block;
 		font-weight: 700;
 		font-size: 15px;
 		color: var(--text-normal);
 		letter-spacing: 0.5px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.name-box {
+		min-width: 0;
+	}
+
+	.display-name-text {
+		display: block;
+		margin-top: 2px;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1.25;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	/* STATUS PILL */

--- a/src/utils/csvParsers.ts
+++ b/src/utils/csvParsers.ts
@@ -32,12 +32,12 @@ export function parseCommoditiesListCSV(csv: string): string[] {
 
 /**
  * Parses CSV from getCommoditiesPriceDataQuery into a Map of price data keyed by symbol.
- * Format: [date_, currency_, price_, logo_, islatest_]
+ * Format: [date_, currency_, displayname_, price_, logo_, islatest_]
  */
 export function parseCommoditiesPriceDataCSV(
     csv: string
-): Map<string, { price: string | null; logo: string | null; date: string | null; isLatest: boolean }> {
-    const priceDataMap = new Map<string, { price: string | null; logo: string | null; date: string | null; isLatest: boolean }>();
+): Map<string, { displayName: string | null; price: string | null; logo: string | null; date: string | null; isLatest: boolean }> {
+    const priceDataMap = new Map<string, { displayName: string | null; price: string | null; logo: string | null; date: string | null; isLatest: boolean }>();
 
     try {
         const cleanCsv = csv.replace(/\r/g, '').trim();
@@ -51,17 +51,18 @@ export function parseCommoditiesPriceDataCSV(
 
         for (let i = 1; i < records.length; i++) {
             const row = records[i];
-            if (row.length < 5) continue;
+            if (row.length < 6) continue;
 
             const date = row[0]?.trim() || null;
             const currency = row[1]?.trim() || null;
-            const price = row[2]?.trim() || null;
-            const logo = row[3]?.trim() || null;
-            const isLatestStr = row[4]?.trim().toLowerCase() || 'false';
+            const displayName = row[2]?.trim() || null;
+            const price = row[3]?.trim() || null;
+            const logo = row[4]?.trim() || null;
+            const isLatestStr = row[5]?.trim().toLowerCase() || 'false';
             const isLatest = isLatestStr === 'true' || isLatestStr === '1';
 
             if (currency) {
-                priceDataMap.set(currency, { price, logo, date, isLatest });
+                priceDataMap.set(currency, { displayName, price, logo, date, isLatest });
             }
         }
 
@@ -74,10 +75,11 @@ export function parseCommoditiesPriceDataCSV(
 
 /**
  * Parses CSV from getCommodityDetailsQuery into a single commodity detail object.
- * Format: [name_, meta_, logo_, pricemetadata_, filename_, lineno_]
+ * Format: [name_, displayname_, meta_, logo_, pricemetadata_, filename_, lineno_]
  */
 export function parseCommodityDetailsCSV(csv: string): {
     symbol: string;
+    displayName: string | null;
     metadata: Record<string, unknown>;
     logo: string | null;
     priceMetadata: string | null;
@@ -86,6 +88,7 @@ export function parseCommodityDetailsCSV(csv: string): {
 } {
     const defaultResult = {
         symbol: '',
+        displayName: null,
         metadata: {},
         logo: null,
         priceMetadata: null,
@@ -106,20 +109,21 @@ export function parseCommodityDetailsCSV(csv: string): {
         if (records.length < 2) return defaultResult;
 
         const row = records[1];
-        if (row.length < 6) return defaultResult;
+        if (row.length < 7) return defaultResult;
 
         const symbol = row[0]?.trim() || '';
-        const metaStr = row[1]?.trim() || '{}';
-        const logo = row[2]?.trim() || null;
-        const priceMetadata = row[3]?.trim() || null;
-        const filename = row[4]?.trim() || null;
-        const linenoStr = row[5]?.trim() || null;
+        const displayName = row[1]?.trim() || null;
+        const metaStr = row[2]?.trim() || '{}';
+        const logo = row[3]?.trim() || null;
+        const priceMetadata = row[4]?.trim() || null;
+        const filename = row[5]?.trim() || null;
+        const linenoStr = row[6]?.trim() || null;
 
         const metadata = parseMetadataString(metaStr);
         const parsedLineno = linenoStr ? parseInt(linenoStr, 10) : NaN;
         const lineno = isNaN(parsedLineno) ? null : parsedLineno;
 
-        return { symbol, metadata, logo, priceMetadata, filename, lineno };
+        return { symbol, displayName, metadata, logo, priceMetadata, filename, lineno };
     } catch (e) {
         Logger.error('Error parsing commodity details CSV:', e, 'CSV:', csv);
         return defaultResult;
@@ -128,7 +132,7 @@ export function parseCommodityDetailsCSV(csv: string): {
 
 /**
  * Parses CSV from getCombinedCommodityDataQuery into a Map keyed by currency symbol.
- * Format: [currency_, units_, valueOp_, price_, logo_]
+ * Format: [currency_, displayname_, units_, valueOp_, price_, logo_]
  *
  * When bean-query's convert() cannot convert to the operating currency (no price
  * directive exists), it returns the original inventory unchanged (e.g. "0.016 ETHW"
@@ -138,8 +142,8 @@ export function parseCommodityDetailsCSV(csv: string): {
 export function parseCombinedCommodityDataCSV(
     csv: string,
     operatingCurrency: string
-): Map<string, { holdings: number; holdingsRaw: string; valueOp: number; price: string | null; logo: string | null }> {
-    const map = new Map<string, { holdings: number; holdingsRaw: string; valueOp: number; price: string | null; logo: string | null }>();
+): Map<string, { displayName: string | null; holdings: number; holdingsRaw: string; valueOp: number; price: string | null; logo: string | null }> {
+    const map = new Map<string, { displayName: string | null; holdings: number; holdingsRaw: string; valueOp: number; price: string | null; logo: string | null }>();
 
     const extractNumber = (cell: string | undefined): number => {
         if (!cell) return 0;
@@ -165,15 +169,16 @@ export function parseCombinedCommodityDataCSV(
 
         for (let i = 1; i < records.length; i++) {
             const row = records[i];
-            if (row.length < 5) continue;
+            if (row.length < 6) continue;
 
             const currency = row[0]?.trim();
             if (!currency) continue;
 
-            const unitsCell = row[1]?.trim() || '';
-            const valueCell = row[2]?.trim() || '';
-            const priceCell = row[3]?.trim() || null;
-            const logoCell = row[4]?.trim() || null;
+            const displayName = row[1]?.trim() || null;
+            const unitsCell = row[2]?.trim() || '';
+            const valueCell = row[3]?.trim() || '';
+            const priceCell = row[4]?.trim() || null;
+            const logoCell = row[5]?.trim() || null;
 
             const holdings = Math.abs(extractNumber(unitsCell));
 
@@ -192,7 +197,7 @@ export function parseCombinedCommodityDataCSV(
             const price = priceCell && priceCell !== 'None' ? priceCell : null;
             const logo = logoCell && logoCell !== 'None' ? logoCell : null;
 
-            map.set(currency, { holdings, holdingsRaw, valueOp, price, logo });
+            map.set(currency, { displayName, holdings, holdingsRaw, valueOp, price, logo });
         }
 
         return map;
@@ -202,3 +207,43 @@ export function parseCombinedCommodityDataCSV(
     }
 }
 
+/**
+ * Parses CSV from getCommodityPriceHistoryQuery into dated price points.
+ * Format: [date_, amount_], where amount_ is typically "123.45 CNY".
+ */
+export function parseCommodityPriceHistoryCSV(csv: string): Array<{ date: string; amount: number; currency: string; amountRaw: string }> {
+    const rows: Array<{ date: string; amount: number; currency: string; amountRaw: string }> = [];
+
+    try {
+        const cleanCsv = csv.replace(/\r/g, '').trim();
+        if (!cleanCsv) return rows;
+
+        const records: string[][] = parseCsv(cleanCsv, {
+            columns: false,
+            skip_empty_lines: true,
+            relax_column_count: true,
+        });
+
+        for (let i = 1; i < records.length; i++) {
+            const row = records[i];
+            if (row.length < 2) continue;
+
+            const date = row[0]?.trim();
+            const amountRaw = row[1]?.trim() || '';
+            const amountMatch = amountRaw.match(/(-?[\d,]+(?:\.\d+)?)\s+([A-Z][A-Z0-9'._-]*)/);
+            if (!date || !amountMatch) continue;
+
+            rows.push({
+                date,
+                amount: parseFloat(amountMatch[1].replace(/,/g, '')),
+                currency: amountMatch[2],
+                amountRaw,
+            });
+        }
+
+        return rows;
+    } catch (e) {
+        Logger.error('Error parsing commodity price history CSV:', e, 'CSV:', csv);
+        return rows;
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,7 +22,7 @@ export {
 	parseMetadataString,
 	debounce,
 } from './formatters';
-export { parseCommoditiesListCSV, parseCommoditiesPriceDataCSV, parseCommodityDetailsCSV, parseCombinedCommodityDataCSV } from './csvParsers';
+export { parseCommoditiesListCSV, parseCommoditiesPriceDataCSV, parseCommodityDetailsCSV, parseCombinedCommodityDataCSV, parseCommodityPriceHistoryCSV } from './csvParsers';
 export { buildAccountTree, getOpenAccounts, getPayees, getTags, getCommodities } from './accounts';
 export { getTransactionEntries, getBalanceEntries, getNoteEntries } from './journal';
 export {


### PR DESCRIPTION
## Summary
- show commodity display names from Beancount `name` metadata in commodity cards and details
- add price history in the commodity detail modal with chart/table views
- improve commodity card and metadata detail layout so long holdings, metadata keys, account paths, and legacy IDs do not overlap or get clipped

## Background
The Commodities page currently focuses on symbols and latest prices. For ledgers with many investment commodities, symbols alone can be hard to identify, and users cannot inspect historical price directives from the detail view. This change reads existing Beancount commodity metadata and price directives instead of introducing a separate data source.

## Verification
- `npm run build`
- `git diff --check`
- tested against a local Beancount ledger where `#commodities` returns `name` metadata and `#prices` returns price history rows
