### PR TITLE
Improve Budget and Target account suggestions

### DIFF
--- a/src/ui/modals/AddBudgetModal.svelte
+++ b/src/ui/modals/AddBudgetModal.svelte
@@ -31,6 +31,9 @@
 	$: filteredAccounts = accountQuery
 		? expenseAccounts.filter(a => a.toLowerCase().includes(accountQuery.toLowerCase()))
 		: expenseAccounts;
+	$: accountSummary = accountQuery
+		? `${filteredAccounts.length} matching expense account${filteredAccounts.length === 1 ? '' : 's'}`
+		: `${expenseAccounts.length} expense account${expenseAccounts.length === 1 ? '' : 's'} available. Type to filter.`;
 	let showDropdown = false;
 
 	onMount(() => {
@@ -124,13 +127,18 @@
 					on:focus={() => (showDropdown = true)}
 					on:blur={() => setTimeout(() => (showDropdown = false), 150)}
 				/>
-				{#if showDropdown && filteredAccounts.length > 0}
+				{#if showDropdown}
 					<ul class="autocomplete-dropdown">
-						{#each filteredAccounts.slice(0, 8) as acc}
-							<!-- svelte-ignore a11y-click-events-have-key-events -->
-							<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-							<li on:click={() => selectAccount(acc)}>{acc}</li>
-						{/each}
+						<li class="autocomplete-summary">{accountSummary}</li>
+						{#if filteredAccounts.length > 0}
+							{#each filteredAccounts as acc}
+								<!-- svelte-ignore a11y-click-events-have-key-events -->
+								<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+								<li on:click={() => selectAccount(acc)}>{acc}</li>
+							{/each}
+						{:else}
+							<li class="autocomplete-empty">No expense accounts match your filter.</li>
+						{/if}
 					</ul>
 				{/if}
 			</div>
@@ -275,7 +283,7 @@
 		background: var(--background-primary);
 		border: 1px solid var(--background-modifier-border);
 		border-radius: var(--radius-s);
-		max-height: 120px;
+		max-height: 240px;
 		overflow-y: auto;
 		list-style: none;
 		margin: 2px 0 0;
@@ -284,12 +292,22 @@
 
 	.autocomplete-dropdown li {
 		padding: var(--size-4-1) var(--size-4-2);
-		cursor: pointer;
 		font-size: var(--font-ui-small);
 	}
 
-	.autocomplete-dropdown li:hover {
+	.autocomplete-dropdown li:not(.autocomplete-summary, .autocomplete-empty) {
+		cursor: pointer;
+	}
+
+	.autocomplete-dropdown li:not(.autocomplete-summary, .autocomplete-empty):hover {
 		background: var(--background-modifier-hover);
+	}
+
+	.autocomplete-summary,
+	.autocomplete-empty {
+		color: var(--text-muted);
+		cursor: default;
+		font-size: var(--font-ui-smaller);
 	}
 
 	.rollover-row {

--- a/src/ui/modals/AddTargetModal.svelte
+++ b/src/ui/modals/AddTargetModal.svelte
@@ -31,6 +31,9 @@
 	$: filteredAccounts = accountQuery
 		? assetAccounts.filter(a => a.toLowerCase().includes(accountQuery.toLowerCase()))
 		: assetAccounts;
+	$: accountSummary = accountQuery
+		? `${filteredAccounts.length} matching asset account${filteredAccounts.length === 1 ? '' : 's'}`
+		: `${assetAccounts.length} asset account${assetAccounts.length === 1 ? '' : 's'} available. Type to filter.`;
 	let showDropdown = false;
 
 	onMount(() => {
@@ -124,13 +127,18 @@
 					on:focus={() => (showDropdown = true)}
 					on:blur={() => setTimeout(() => (showDropdown = false), 150)}
 				/>
-				{#if showDropdown && filteredAccounts.length > 0}
+				{#if showDropdown}
 					<ul class="autocomplete-dropdown">
-						{#each filteredAccounts.slice(0, 8) as acc}
-							<!-- svelte-ignore a11y-click-events-have-key-events -->
-							<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-							<li on:click={() => selectAccount(acc)}>{acc}</li>
-						{/each}
+						<li class="autocomplete-summary">{accountSummary}</li>
+						{#if filteredAccounts.length > 0}
+							{#each filteredAccounts as acc}
+								<!-- svelte-ignore a11y-click-events-have-key-events -->
+								<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+								<li on:click={() => selectAccount(acc)}>{acc}</li>
+							{/each}
+						{:else}
+							<li class="autocomplete-empty">No asset accounts match your filter.</li>
+						{/if}
 					</ul>
 				{/if}
 			</div>
@@ -275,7 +283,7 @@
 		background: var(--background-primary);
 		border: 1px solid var(--background-modifier-border);
 		border-radius: var(--radius-s);
-		max-height: 120px;
+		max-height: 240px;
 		overflow-y: auto;
 		list-style: none;
 		margin: 2px 0 0;
@@ -284,12 +292,22 @@
 
 	.autocomplete-dropdown li {
 		padding: var(--size-4-1) var(--size-4-2);
-		cursor: pointer;
 		font-size: var(--font-ui-small);
 	}
 
-	.autocomplete-dropdown li:hover {
+	.autocomplete-dropdown li:not(.autocomplete-summary, .autocomplete-empty) {
+		cursor: pointer;
+	}
+
+	.autocomplete-dropdown li:not(.autocomplete-summary, .autocomplete-empty):hover {
 		background: var(--background-modifier-hover);
+	}
+
+	.autocomplete-summary,
+	.autocomplete-empty {
+		color: var(--text-muted);
+		cursor: default;
+		font-size: var(--font-ui-smaller);
 	}
 
 	.rollover-row {


### PR DESCRIPTION
## Summary
- Remove the hard 8-item cap from Budget and Target account autocomplete lists.
- Keep the existing account-type filtering: Budgets suggest `Expenses` accounts, Targets suggest `Assets` accounts.
- Add a result count / empty-state row so users can tell whether the list is complete or needs filtering.
- Increase the dropdown height and allow scrolling through all matching accounts.

## Background
On ledgers with many open accounts, the Add Target modal only rendered the first 8 matching asset accounts. This made it look like most accounts were missing even though the ledger query had returned them. The same autocomplete pattern existed in Add Budget.

## Verification
- `npm run build`
- `git diff --check`
- Tested against a local ledger with 235 open `Assets` accounts to confirm the issue was UI truncation rather than missing account data.