### PR TITLE
fix(commodities): show holdings as quantity

### DIFF
--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -13,6 +13,11 @@
 		return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 	}
 
+	function formatQuantity(n: number | null | undefined): string {
+		if (!n) return '0';
+		return n.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 4 });
+	}
+
 	const dispatch = createEventDispatcher();
 
 	function handleClick() {
@@ -145,10 +150,9 @@
 					<span class="value-currency">{operatingCurrency}</span>
 				</div>
 			{:else if commodity?.holdingsRaw && !commodity?.isOperatingCurrency}
-				<!-- Has holdings but no price to convert — show raw units -->
+				<!-- Has holdings but no price to convert — show quantity, not a value currency. -->
 				<div class="value-container" title={commodity.holdingsRaw}>
-					<span class="value-main no-price">{commodity.holdingsRaw.split(' ')[0]}</span>
-					<span class="value-currency">{commodity.symbol}</span>
+					<span class="value-main no-price">{formatQuantity(commodity.holdings)}</span>
 				</div>
 			{:else}
 				<div class="value-container">
@@ -182,9 +186,9 @@
 				<div class="data-row">
 					<span class="data-label">Holdings</span>
 					{#if commodity?.holdingsRaw}
-						<span class="data-value" title={commodity.holdingsRaw}>{commodity.holdingsRaw}</span>
+						<span class="data-value" title={commodity.holdingsRaw}>{formatQuantity(commodity.holdings)}</span>
 					{:else}
-						<span class="data-value unavailable">0 {commodity?.symbol}</span>
+						<span class="data-value unavailable">0</span>
 					{/if}
 				</div>
 			{/if}

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -150,9 +150,9 @@
 					<span class="value-currency">{operatingCurrency}</span>
 				</div>
 			{:else if commodity?.holdingsRaw && !commodity?.isOperatingCurrency}
-				<!-- Has holdings but no price to convert — show quantity, not a value currency. -->
+				<!-- Has holdings but no price to convert, so no market value is available. -->
 				<div class="value-container" title={commodity.holdingsRaw}>
-					<span class="value-main no-price">{formatQuantity(commodity.holdings)}</span>
+					<span class="value-main no-price">No value</span>
 				</div>
 			{:else}
 				<div class="value-container">

--- a/src/ui/partials/dashboard/cards/CommodityCard.svelte
+++ b/src/ui/partials/dashboard/cards/CommodityCard.svelte
@@ -18,6 +18,20 @@
 		return n.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 4 });
 	}
 
+	const fiatCurrencySymbols = new Set([
+		'AUD',
+		'CAD',
+		'CHF',
+		'CNY',
+		'EUR',
+		'GBP',
+		'HKD',
+		'JPY',
+		'NZD',
+		'SGD',
+		'USD',
+	]);
+
 	const dispatch = createEventDispatcher();
 
 	function handleClick() {
@@ -91,6 +105,9 @@
 	}
 
 	$: displayName = commodity?.displayName || commodity?.metadata?.name || "";
+	$: isFiatCurrency = fiatCurrencySymbols.has(commodity?.symbol || '');
+	$: priceLabel = isFiatCurrency ? 'FX Rate' : 'Unit Price';
+	$: holdingsLabel = isFiatCurrency ? 'Balance' : 'Units';
 	$: ariaLabel = displayName
 		? `View details for ${commodity?.symbol || `UNKNOWN_${index}`} (${displayName})`
 		: `View details for ${commodity?.symbol || `UNKNOWN_${index}`}`;
@@ -174,7 +191,7 @@
 			{:else}
 				<!-- Price row -->
 				<div class="data-row">
-					<span class="data-label">Price</span>
+					<span class="data-label">{priceLabel}</span>
 					{#if commodity?.currentPrice}
 						<span class="data-value" title={commodity.currentPrice}>{commodity.currentPrice}</span>
 					{:else}
@@ -184,7 +201,7 @@
 
 				<!-- Holdings row -->
 				<div class="data-row">
-					<span class="data-label">Holdings</span>
+					<span class="data-label">{holdingsLabel}</span>
 					{#if commodity?.holdingsRaw}
 						<span class="data-value" title={commodity.holdingsRaw}>{formatQuantity(commodity.holdings)}</span>
 					{:else}
@@ -479,7 +496,7 @@
 	/* Price + Holdings rows */
 	.data-row {
 		display: grid;
-		grid-template-columns: 78px minmax(0, 1fr);
+		grid-template-columns: 92px minmax(0, 1fr);
 		align-items: baseline;
 		gap: 10px;
 		padding: 6px 0;


### PR DESCRIPTION
## Summary
- Show commodity holdings as plain quantities instead of appending the commodity symbol in the card rows.
- Avoid displaying an unpriced quantity as if the commodity symbol were a value currency.
- Keep the raw Beancount units in the hover title for traceability.

## Test Plan
- npm run build