### PR TITLE
fix(settings): command verification always fails — timeout passed in args position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## In-progress
 
+- **Connection Settings: Fix bean-query/bean-price "Verify" always failing** — The Verify and Test buttons in *Settings → Connection* passed the timeout (`15000`/`10000`) as the second argument to `SystemDetector.testCommand`, whose second parameter is the **args array**, not the timeout. The number was spread in `execSafe` (`[...parts.slice(1), ...additionalArgs]`), throwing a `TypeError: x is not iterable` that was caught and reported as a generic "Verification failed", so verification could never succeed regardless of a valid configuration. Fixed all four call sites to pass `[]` for args and the timeout in the correct position, and hardened `execSafe` to reject a non-array `additionalArgs` with a clear, actionable message instead of an opaque crash.
+
 - **Multi-Currency Warning: Clarify warning column wording** — Updated the multi-currency warnings on the Balance Sheet and Income Statement to reference the specific reporting currency name instead of positional column descriptions like 'first column' and 'second column' to prevent user confusion. Merged PR #230.
 
 - **Income Statement: Fix Net Profit trend signs and show income as positive** — Updated the income statement and net profit trend charts to display conventional signs (positive values for profit and negative values for loss), negating credit accounts at the source so income balances render as positive. Adjusted chart colors (green for profit, red for loss) and fixed the anomalous stripes rendering on the Income Sunburst Chart. Merged PR #238.

--- a/src/ui/partials/settings/ConnectionSettings.svelte
+++ b/src/ui/partials/settings/ConnectionSettings.svelte
@@ -184,6 +184,7 @@
 			const systemDetector = SystemDetector.getInstance();
 			const testResult = await systemDetector.testCommand(
 				commandTests.beanQuery.command,
+				[],
 				15000,
 			);
 
@@ -214,6 +215,7 @@
 			const systemDetector = SystemDetector.getInstance();
 			const testResult = await systemDetector.testCommand(
 				commandTests.beanQueryCsv.command,
+				[],
 				15000,
 			);
 
@@ -389,7 +391,7 @@
 		try {
 			const systemDetector = SystemDetector.getInstance();
 			const command = `${commandToVerify.trim()} -f csv "${plugin.settings.beancountFilePath}" "SELECT TRUE LIMIT 1"`;
-			const result = await systemDetector.testCommand(command, 15000);
+			const result = await systemDetector.testCommand(command, [], 15000);
 			if (result.success) {
 				commandVerificationStatus = "success";
 				commandVerificationMessage = "✅ Command verified successfully";
@@ -423,6 +425,7 @@
 			const systemDetector = SystemDetector.getInstance();
 			const result = await systemDetector.testCommand(
 				`${cmd.trim()} --help`,
+				[],
 				10000,
 			);
 			if (result.success) {

--- a/src/utils/execSafe.ts
+++ b/src/utils/execSafe.ts
@@ -53,6 +53,17 @@ export function execSafe(
     options: ExecSafeOptions = {}
 ): Promise<{ stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
+        // Guard against a non-array being passed in the args position (a common
+        // mistake is passing a timeout number here). Spreading a non-iterable
+        // would otherwise throw an opaque "x is not iterable" TypeError that
+        // callers surface as a misleading generic failure.
+        if (!Array.isArray(additionalArgs)) {
+            return reject(new Error(
+                `Invalid arguments: expected a string[] of additional args but received ${typeof additionalArgs}. ` +
+                `Did you mean to pass options? Use execSafe(command, [], { timeout }).`
+            ));
+        }
+
         const parts = splitCommandLine(commandLine.trim());
         const command = parts[0];
         const args = [...parts.slice(1), ...additionalArgs];


### PR DESCRIPTION
## What

Fixes the **Verify** / **Test** buttons in *Settings → Connection*, which always
report `❌ Verification failed` even when `bean-query`/`bean-price`, the ledger
path, and the query are all valid.

## Root cause

`SystemDetector.testCommand` has the signature:

```ts
async testCommand(command: string, args: string[] = [], timeout = 5000)
```

But four call sites in `src/ui/partials/settings/ConnectionSettings.svelte` pass
the **timeout** as the second argument — i.e. in the `args` position:

| Function | Buggy call |
|---|---|
| `testBeanQuery` | `testCommand(commandTests.beanQuery.command, 15000)` |
| `testBeanQueryCsv` | `testCommand(commandTests.beanQueryCsv.command, 15000)` |
| `verifyCommand` | `testCommand(command, 15000)` |
| `verifyBeanPriceCommand` | `testCommand(\`${cmd.trim()} --help\`, 10000)` |

`testCommand` forwards `args` to `execSafe` as `additionalArgs`, which builds the
spawn argument list with a spread (`src/utils/execSafe.ts`):

```ts
const args = [...parts.slice(1), ...additionalArgs];
```

Spreading the number `15000` throws `TypeError: 15000 is not iterable`. The error
is caught inside `testCommand` and returned as `{ success: false, error: "...is
not iterable" }`, which the UI renders as a generic verification failure. As a
result verification can **never** succeed, and the intended 15s/10s timeout is
never applied either.

## Fix

1. **Call sites** — pass `[]` for `args` and the timeout in the correct (third)
   position, e.g. `testCommand(command, [], 15000)`.
2. **Defense-in-depth** — `execSafe` now rejects a non-array `additionalArgs` with
   a clear, actionable message instead of an opaque "not iterable" crash, so the
   same mistake can't silently masquerade as a config failure again.

## Testing

- Reproduced on installed build v2.2.0: Verify failed with a valid config; the
  underlying `bean-query -f csv "<ledger>" "SELECT TRUE LIMIT 1"` returned `TRUE`
  from a shell.
- With the fix, a standalone harness replicating `execSafe`/`testCommand` against
  a real ledger returns `{ success: true, output: "TRUE\n" }` for the corrected
  call, and a descriptive error (not a `TypeError`) for the old buggy call shape.
- `tsc -noEmit -skipLibCheck`: no new type errors introduced (pre-existing
  `@codemirror`/`@lezer` resolution errors are unrelated and unchanged).

## Scope

Minimal, low-risk: 4 one-line call-site corrections + a guard clause. No behavior
change for callers already passing an args array.
